### PR TITLE
Add AI-assistant knowledge base and refresh README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ config/mongoid.yml
 
 # Gem lockfile (library gem — consumers generate their own)
 /Gemfile.lock
+
+# Override the global `docs/*` ignore so the AI-assistant docs in docs/*.md
+# track with the repo. The global rule still covers anything non-Markdown
+# that happens to land in docs/ (e.g. generated coverage HTML).
+!docs/*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,291 @@
+# AGENTS.md — `cgminer_monitor`
+
+Consolidated context for AI coding assistants. For end-user docs, see [`README.md`](README.md). For the 1.0 rewrite history and upgrade path from 0.x, see [`CHANGELOG.md`](CHANGELOG.md) and [`MIGRATION.md`](MIGRATION.md). For deep dives on any topic below, see [`docs/`](docs/) (start with [`docs/index.md`](docs/index.md)).
+
+## Table of contents
+
+- [What this is](#what-this-is)
+- [Repo layout](#repo-layout) *(which files are shipped, which aren't)*
+- [How the pieces fit together](#how-the-pieces-fit-together)
+- [Conventions that matter when editing code](#conventions-that-matter-when-editing-code)
+- [Running tests and lint](#running-tests-and-lint)
+- [Adding a new HTTP endpoint](#adding-a-new-http-endpoint)
+- [Adding a new extracted metric](#adding-a-new-extracted-metric)
+- [Ruby and Mongo version support](#ruby-and-mongo-version-support)
+- [Gotchas worth knowing up front](#gotchas-worth-knowing-up-front)
+- [Release process](#release-process)
+- [Where to look for deeper context](#where-to-look-for-deeper-context)
+
+---
+
+## What this is
+
+<!-- metadata: overview, stack, purpose -->
+
+A standalone Ruby daemon that polls [cgminer](https://github.com/ckolivas/cgminer) instances, stores device/pool/summary/stats data in MongoDB, and serves a read-only HTTP API. **Not** a Rails engine anymore — the 1.0 rewrite (April 2026) made it a plain foreground process run under a supervisor (systemd, Docker, launchd).
+
+**Stack:** Ruby 3.2+ (gemspec floor), MongoDB 5.0+ (time-series collections). Runtime deps: `cgminer_api_client ~> 0.3.0`, `mongoid ~> 9.0`, `sinatra >= 4.0`, `puma >= 6.0`, `rack-cors ~> 2.0`. Dev deps: `rspec`, `rubocop` (+ `-rake`, `-rspec`), `rack-test`, `rake`, `simplecov`.
+
+**Footprint:** ~1050 SLOC in `lib/`, ~2250 SLOC in `spec/`. Small, well-tested.
+
+**Execution model:** CLI subcommand `cgminer_monitor run` starts one process with two threads — Poller (cgminer → Mongo) and Puma (HTTP out). SIGTERM/SIGINT → graceful shutdown with timeout, exit 0. Config validation failure → exit 78. Anything else bad → exit 1.
+
+## Repo layout
+
+<!-- metadata: directory-structure, file-organization -->
+
+```
+├── bin/cgminer_monitor             # CLI: run / migrate / doctor / version (packaged)
+├── lib/cgminer_monitor.rb          # require graph only
+├── lib/cgminer_monitor/
+│   ├── config.rb                   # Data.define Config from env, validation, redaction
+│   ├── errors.rb                   # Error < StandardError, ConfigError, StorageError*, PollError*
+│   ├── logger.rb                   # Structured JSON/text logger (module singleton, thread-safe)
+│   ├── sample.rb                   # Mongoid: samples (time-series, ts/meta/v)
+│   ├── sample_query.rb             # Read-side: hashrate, temperature, availability series
+│   ├── snapshot.rb                 # Mongoid: latest_snapshot (regular, upserted per poll)
+│   ├── snapshot_query.rb           # Read-side: for_miner, miners, last_poll_at
+│   ├── poller.rb                   # Polling loop, sample extraction, bulk writes to Mongo
+│   ├── server.rb                   # Orchestrator: signals, Mongoid, Poller, Puma, shutdown
+│   ├── http_app.rb                 # Sinatra app: /v2/*, /metrics, /openapi.yml, /docs
+│   ├── openapi.yml                 # OpenAPI 3.1 (packaged, served at /openapi.yml, CI-guarded)
+│   └── version.rb                  # VERSION = "1.0.0"
+├── spec/                           # RSpec unit + integration (NOT packaged)
+│   ├── cgminer_monitor/            # Unit specs, one per lib/ file
+│   ├── integration/                # full_pipeline, cli, healthz
+│   ├── openapi_consistency_spec.rb # route ↔ openapi.yml parity guard
+│   └── support/                    # FakeCgminer, CgminerFixtures, mongo_helper
+├── config/miners.yml.example       # NOT packaged (gemspec omits it deliberately)
+├── docs/                           # AI-assistant knowledge base (this is where you're reading from)
+├── .github/workflows/ci.yml        # lint + test matrix + integration + openapi-check jobs
+├── .rubocop.yml                    # TargetRubyVersion 3.2; Metrics/* cops largely off
+├── .rspec / .ruby-version
+├── Rakefile                        # default: [spec, rubocop]
+├── Dockerfile                      # Multi-stage, ruby:3.4-slim base
+├── docker-compose.yml              # mongo + cgminer_monitor + optional fake_cgminer
+├── Gemfile                         # ostruct conditional pin for Ruby >= 3.5
+├── cgminer_monitor.gemspec
+├── CHANGELOG.md                    # Keep-a-Changelog; 1.0.0 notes
+├── MIGRATION.md                    # 0.x → 1.0 upgrade guide for consumers
+├── README.md
+└── LICENSE.txt                     # MIT
+```
+
+*`StorageError` and `PollError` are declared in `errors.rb` but not currently raised anywhere — shelfware from the 1.0 rewrite. See `docs/review_notes.md`.
+
+**What's packaged in the gem** (gemspec `spec.files`): `lib/**/*.rb`, `lib/**/*.yml` (the OpenAPI spec), `bin/*`, `README.md`, `LICENSE.txt`, `CHANGELOG.md`, `cgminer_monitor.gemspec`. Everything else (specs, configs, Docker, MIGRATION, `docs/`, CI workflows) is dev-only. Notably `config/miners.yml.example` is NOT packaged — the docker-compose expects the operator to mount their own.
+
+## How the pieces fit together
+
+<!-- metadata: architecture, dataflow -->
+
+```
+bin/cgminer_monitor run
+      │
+      ▼
+   Server ──install signal handlers──► @stop: Queue
+      │
+      ├──configure Mongoid──► Mongo
+      ├──bootstrap samples + snapshot collections
+      │
+      ├──spawn Poller thread ──► cgminer_api_client::MinerPool ──TCP──► cgminer instances
+      │                              │
+      │                              └──► Sample.insert_many + Snapshot.bulk_write ──► Mongo
+      │
+      └──spawn Puma thread ──► HttpApp ──► SampleQuery / SnapshotQuery ──► Mongo
+
+   SIGTERM/SIGINT ──► push to @stop ──► poller.stop + launcher.stop ──► exit 0
+```
+
+**Key structural facts:**
+
+1. **Two threads, one process, one `@stop` Queue.** Poller runs a `while !stopped` loop; Puma runs until `launcher.stop`. Main thread blocks on `@stop.pop` until a signal handler (or a Puma crash) pushes something.
+2. **`HttpApp` has class-level state** set by `Server` at boot: `.poller`, `.started_at`, `.configured_miners_cache`. Tests must call `HttpApp.reset_configured_miners!` between examples.
+3. **`Config` is immutable.** `Data.define`. Validated once in `Config.from_env`. There's no hot reload. Config changes require a restart.
+4. **Mongoid is configured programmatically** from `CGMINER_MONITOR_MONGO_URL`. No `config/mongoid.yml` exists. This was explicit in the 1.0 rewrite.
+5. **`Sample.store_in` is called at runtime**, not as a class macro, because the `expire_after` depends on `Config#retention_seconds`. `Sample.create_collection` is called explicitly so the collection is actually time-series (not a regular lazy-created one).
+6. **Poller bypasses `CgminerApiClient::MinerPool.new`** because that constructor hard-codes `'config/miners.yml'` relative to CWD — which doesn't honor `CGMINER_MONITOR_MINERS_FILE`. Uses `MinerPool.allocate` + manual `.miners=`.
+7. **OpenAPI is source of truth.** `spec/openapi_consistency_spec.rb` walks `HttpApp`'s routes and checks against `lib/cgminer_monitor/openapi.yml`. Adding/removing routes requires updating the YAML in the same commit.
+
+## Conventions that matter when editing code
+
+<!-- metadata: coding-style, conventions, best-practices -->
+
+### Ruby style
+
+- **Every file starts with `# frozen_string_literal: true`.** New files too.
+- **`Data.define` for immutable value objects**, not `Struct` or custom classes. See `Config`.
+- **Explicit `StandardError` in bare rescues** (`rescue StandardError => e`). The one exception is `rescue Exception` inside the Puma thread crash handler in `Server#run` — it's there on purpose, with a RuboCop disable comment.
+- **Structured logging everywhere.** Use `Logger.info(event: '...', ...)` with keyword arguments. Every event has an `event:` name for grep-ability. No class in `lib/` uses `warn`, `puts`, or `$stderr` directly. The only direct `warn` calls are in `bin/cgminer_monitor` for top-level error messages.
+- **`YAML.safe_load_file`**, not `YAML.load_file`.
+- **Don't mutate `Config` at runtime.** If you find yourself wanting to, that's the wrong tool — add an env var, bump the supervisor to restart.
+
+### RuboCop
+
+- `.rubocop.yml` disables most `Metrics/*` cops and most `RSpec/*` style cops. Short parameter names (`ok`, `ts`, `v`) are allowed via `Naming/MethodParameterName` because they're idiomatic for Mongo.
+- Correctness cops (`RSpec/RepeatedExample`, `RSpec/LeakyConstantDeclaration`, etc.) stay on.
+- `bundle exec rake` runs specs + rubocop as the default task.
+
+### Commit style
+
+- **One commit per logical step.** Multi-step changes should land with one commit per step, and `bundle exec rake` should pass before each commit.
+- Imperative mood ("Add X", "Fix Y"), kept tight. Look at recent `git log` for the project's voice.
+
+### Error handling
+
+- New errors should subclass `CgminerMonitor::Error` (and typically one of `ConfigError`, `StorageError`, `PollError`). Don't add a sibling class unless you have a real reason.
+- **Rescue narrowly.** `Poller#poll_once` catches `Mongo::Error` separately from `StandardError` so Mongo outages show up as a distinct log event. Follow that pattern.
+- **Don't silently swallow.** The Poller's `rescue StandardError => e; increment_failed; Logger.error(...)` looks like a catch-all, but it's *logged* with backtrace. If you add a new rescue, log it too.
+- `Server#run`'s top-level `rescue StandardError` returns exit code 1. `ConfigError` caught in `bin/cgminer_monitor` returns exit 78. Don't route new errors through the generic path if they have a specific treatment.
+
+### Testing
+
+- **Unit specs live at `spec/cgminer_monitor/**`**, one file per `lib/` file. Integration specs at `spec/integration/`.
+- **Integration specs use a real MongoDB** and `FakeCgminer` (shared with `cgminer_api_client` via `spec/support/fake_cgminer.rb`). Mongo comes from `CGMINER_MONITOR_MONGO_URL` env; in CI it's a service container, locally it's `docker run mongo:7`.
+- **HTTP specs use `Rack::Test::Methods`** against `HttpApp` directly — no Puma spin-up.
+- **CLI integration specs spawn the real binary** via `Open3.capture3` and assert on exit codes and stream contents.
+- **`spec/openapi_consistency_spec.rb`** is a CI guard. Keep it passing.
+- **`config.order = :random`** — specs must be order-independent.
+- **`mocks.verify_partial_doubles = true`** — doubles must match real method signatures.
+- Warnings are on in `.rspec`. Keep the suite warning-clean.
+- Between specs that touch `HttpApp.configured_miners_cache`, call `HttpApp.reset_configured_miners!`.
+
+## Running tests and lint
+
+<!-- metadata: testing, local-dev, commands -->
+
+```sh
+# Prereq: MongoDB available (for integration specs and anything that touches Mongoid)
+docker run -d --name cgminer-mongo-test -p 27017:27017 mongo:7
+
+bundle install
+bundle exec rake                                       # spec + rubocop (default)
+bundle exec rspec                                      # all specs
+bundle exec rspec spec/cgminer_monitor                 # unit only
+bundle exec rspec spec/integration                     # integration only
+bundle exec rspec spec/openapi_consistency_spec.rb     # openapi parity only
+bundle exec rspec path/to/spec.rb:123                  # single example
+bundle exec rubocop                                    # lint only
+bundle exec rubocop -A                                 # lint + auto-correct
+```
+
+**Coverage** is always on (SimpleCov in `spec_helper.rb`). Reports in `coverage/` — `.gitignore`d.
+
+**Manual sandbox** without real miners:
+
+```sh
+# With docker-compose
+docker-compose --profile testing up   # Mongo + cgminer_monitor + FakeCgminer
+
+# Or manually
+docker run -d -p 27017:27017 mongo:7
+cp config/miners.yml.example config/miners.yml  # then edit for your FakeCgminer port
+bundle exec bin/cgminer_monitor doctor          # check connectivity
+bundle exec bin/cgminer_monitor run
+```
+
+## Adding a new HTTP endpoint
+
+<!-- metadata: extending, how-to -->
+
+1. **Add the Sinatra route** in `lib/cgminer_monitor/http_app.rb`:
+   ```ruby
+   get '/v2/my_new_thing' do
+     # ... read from SampleQuery or SnapshotQuery (or add a new query method there)
+     JSON.generate({ ... })
+   end
+   ```
+2. **Update the OpenAPI spec** at `lib/cgminer_monitor/openapi.yml`. Add a `paths: /v2/my_new_thing:` entry with request params, response shape, and status codes. Required — `spec/openapi_consistency_spec.rb` will fail CI otherwise.
+3. **Write a unit spec** in `spec/cgminer_monitor/http_app_spec.rb` using `Rack::Test`. Cover: happy path, error cases, edge cases on query parameters.
+4. **If the endpoint touches new data**, add a query method in `SampleQuery` or `SnapshotQuery` (or a new sibling module) rather than querying from `HttpApp` directly. Keep HTTP routing separate from storage access.
+5. **Update the README's endpoints table** if this is user-facing.
+6. **Don't add auth.** The app is designed for trusted networks; adding auth piecemeal would be worse than having it clearly in scope.
+
+## Adding a new extracted metric
+
+<!-- metadata: extending, how-to -->
+
+`Poller#extract_samples` is the one place that knows how to turn a cgminer response into sample rows.
+
+1. **No code change needed** if the new metric is already a numeric field on a cgminer command's response. `extract_samples` walks every field via `response[COMMAND_KEY].each` and emits a sample for anything that passes `to_numeric`. The new field will just start showing up in `samples` on the next poll.
+2. **For derived / synthetic metrics** (like the existing `poll.ok` and `poll.duration_ms`), add them in `Poller#append_synthetic_samples`.
+3. **For per-metric query helpers** (like `SampleQuery.hashrate`), add a method to `SampleQuery` that scopes by `meta.metric`. Update the relevant HTTP endpoint.
+4. **If the metric becomes part of Prometheus exposition**, update `HttpApp#build_prometheus_metrics` and add `# HELP` / `# TYPE` lines.
+5. **Tests:** exercise the new extraction via an integration spec using `FakeCgminer` fixtures, not just unit-level mocks.
+
+## Ruby and Mongo version support
+
+<!-- metadata: runtime, compatibility -->
+
+- **Ruby minimum: 3.2.** Gemspec enforces. CI matrix: 3.2/3.3/3.4 required, 4.0 and head best-effort.
+- **Mongo minimum: 5.0** (required for time-series collections). CI uses 6.0 and 7.0 because 5.0 isn't available as a GitHub Actions service. The 5.0 floor is asserted but not tested in CI directly.
+- **Local dev:** `.ruby-version` pins a specific Ruby (currently 3.4-ish).
+
+**Sharp edges:**
+- Ruby 3.4 deprecates some `ostruct` usage that Mongoid 9 still does. The CLI integration spec tolerates the deprecation warnings on stderr.
+- Ruby 4.0 removed `ostruct` from default gems entirely — `Gemfile` conditionally pins `gem 'ostruct'` when `RUBY_VERSION >= '3.5'` as a compatibility shim.
+- Mongoid 9 caps `bson < 6`. When bson 6 ships, we can't upgrade until Mongoid 10.
+- `Data.define` requires Ruby 3.2+. Used for `Config`.
+- Time-series collections require Mongo 5.0+. `Sample.create_collection` with `collection_options: time_series: {...}` will fail on older Mongo.
+
+## Gotchas worth knowing up front
+
+<!-- metadata: caveats, surprises -->
+
+These are real past-incident-shaped corners. Keep them in mind before "cleaning up" related code:
+
+1. **Signal handlers must be installed before `Puma::Launcher.run`, then reinstalled after.** Puma's `setup_signals` synchronously overwrites process-wide handlers. `Server#install_signal_handlers` runs first (pre-Puma). Then Puma starts in its own thread. Then `Server#reinstall_signal_handlers` waits 50ms and reinstalls. The `sleep 0.05` is a heuristic handoff, not a correctness guarantee — if you change how Puma starts, re-verify SIGTERM still routes through the `@stop` queue.
+
+2. **`raise_exception_on_sigterm false`** in `Server#build_puma_launcher` is load-bearing. By default Puma raises `SignalException` on SIGTERM, which would bubble out of the Puma thread and miss our `@stop`-queue path. Don't remove it.
+
+3. **`Poller#build_miner_pool` uses `MinerPool.allocate` + `.miners=`.** That's because `CgminerApiClient::MinerPool.new` hard-codes `'config/miners.yml'` relative to CWD. If `cgminer_api_client` ever grows a constructor that accepts a path, we can delete the `.allocate` ceremony. Until then, keep it.
+
+4. **`Sample` doesn't have `store_in` as a class macro.** It's called at runtime from `Server#bootstrap_mongoid!` (and from `cgminer_monitor migrate`) because the `expire_after` TTL depends on runtime config. `create_collection` is also called explicitly because Mongoid's lazy-create would make a regular collection, not a time-series one. Don't move the `store_in` back to class-load time.
+
+5. **`HttpApp` has class-level state set by `Server` at boot.** If you add new state, add a `reset_*!` helper and call it in test setup. If you try to move it to instance state, you'll have to invent a way to get a reference to the current instance into Sinatra's class-level route blocks, which is the bad old dance.
+
+6. **`DEBUG=1` is documented in the README env table but not wired up.** `Server#run` logs backtraces on `server.crash` unconditionally. The env knob exists on paper only. Either wire it up or remove it — flagged in `docs/review_notes.md`.
+
+7. **`StorageError` and `PollError` are declared but never raised.** Shelfware from the 1.0 rewrite. Don't refactor code to raise them without also making sure tests cover the new raising code paths.
+
+8. **`config/miners.yml` path is configurable via env var**, but the *default* is `'config/miners.yml'` which is CWD-relative. If you run `cgminer_monitor run` from a directory without a `config/` subdir, you need to set `CGMINER_MONITOR_MINERS_FILE` to an absolute path.
+
+9. **`Mongo::Error` from `insert_many`/`bulk_write` is logged but not re-raised** in `Poller#poll_once`. So a mid-poll Mongo outage leaves the process running but with `polls_failed` climbing. This is intentional — the supervisor model owns restarts, and a transient Mongo blip shouldn't blow up the process. But it means `/healthz` → `degraded` is how you see it, not a process crash.
+
+10. **Out-of-band git changes are normal.** Don't treat surprising git state (uncommitted changes you didn't make, a new branch you didn't create) as a tool malfunction — the maintainer works outside the assistant session.
+
+## Release process
+
+<!-- metadata: release, publishing -->
+
+Not automated. On a clean `master`:
+
+```sh
+bundle exec rake                                  # must pass clean
+# bump VERSION in lib/cgminer_monitor/version.rb
+# update CHANGELOG.md under a new version section (Keep-a-Changelog format)
+git commit -am "Release vX.Y.Z"
+gem build cgminer_monitor.gemspec                 # produces cgminer_monitor-X.Y.Z.gem
+gem push cgminer_monitor-X.Y.Z.gem                # requires 2FA (rubygems_mfa_required=true)
+git tag vX.Y.Z
+git push origin master vX.Y.Z
+```
+
+Container images (Docker Hub / GHCR) are not currently pushed by CI. If that happens later, it'd be a separate workflow triggered on tag push.
+
+## Where to look for deeper context
+
+<!-- metadata: doc-navigation -->
+
+| Question | File |
+|---|---|
+| How do the classes relate architecturally? Why two threads? Why this signal dance? | [`docs/architecture.md`](docs/architecture.md) |
+| What does each class do? | [`docs/components.md`](docs/components.md) |
+| What's the public method signature for X? HTTP endpoint Y? env var Z? | [`docs/interfaces.md`](docs/interfaces.md) |
+| What's in a `Sample`? What's in `latest_snapshot`? What errors can be raised? | [`docs/data_models.md`](docs/data_models.md) |
+| How does a poll cycle flow? How does startup/shutdown work? Release process? | [`docs/workflows.md`](docs/workflows.md) |
+| Runtime deps? Why Mongo 5+? CI matrix? | [`docs/dependencies.md`](docs/dependencies.md) |
+| Known doc/code drift, caveats, cleanup recommendations | [`docs/review_notes.md`](docs/review_notes.md) |
+| Full knowledge-base index | [`docs/index.md`](docs/index.md) |
+| User-facing docs | [`README.md`](README.md) |
+| Release history and 0.x → 1.0 migration guide | [`CHANGELOG.md`](CHANGELOG.md), [`MIGRATION.md`](MIGRATION.md) |

--- a/README.md
+++ b/README.md
@@ -132,6 +132,27 @@ WantedBy=multi-user.target
 | `cgminer_monitor doctor` | Validate config, test Mongo + miner connectivity |
 | `cgminer_monitor version` | Print version and exit |
 
+### Exit codes
+
+Exit codes follow [`sysexits(3)`](https://man.openbsd.org/sysexits.3):
+
+| Code | Meaning |
+|---|---|
+| `0` | Clean shutdown (signal-driven for `run`; normal completion for `migrate`/`doctor`/`version`). |
+| `1` | Unexpected crash (`run`), or a MongoDB error during `migrate`. |
+| `64` | `EX_USAGE` — unknown or missing command. |
+| `78` | `EX_CONFIG` — configuration validation failed (`run` or `migrate`). |
+
+### Logging
+
+The service writes structured log lines to stdout — one JSON object per line by default. Every line includes `ts`, `level`, `event`, plus event-specific fields. Library code never writes directly to stderr; the CLI itself only uses stderr for top-level error messages and usage hints.
+
+Toggles:
+- `CGMINER_MONITOR_LOG_FORMAT=text` switches to a tokenized `ts LEVEL event k=v` format for human reading. `json` (default) is what most log aggregators want.
+- `CGMINER_MONITOR_LOG_LEVEL` filters at `debug` / `info` / `warn` / `error`. Default is `info`; raise to `warn`/`error` to reduce volume in production, or drop to `debug` when troubleshooting.
+
+Notable events you'll see: `server.start`, `server.stopping`, `server.stopped`, `poll.complete`, `poll.miner_failed`, `poll.unexpected_error`, `mongo.write_failed`, `startup.mongo_unreachable`, `healthz.mongo_unreachable`, `http.unhandled_error`. Use these as the primary signal for monitoring pipelines.
+
 ## API Reference
 
 The HTTP API is available at `http://localhost:9292` by default. Interactive documentation is at [`/docs`](http://localhost:9292/docs) (Swagger UI).
@@ -185,6 +206,13 @@ See [MIGRATION.md](MIGRATION.md) for a detailed guide on migrating from cgminer_
 ## Security
 
 The HTTP API has **no authentication or authorization**. It is designed for trusted local networks. If exposing to untrusted networks, place it behind a reverse proxy with authentication.
+
+## Further Reading
+
+- [`CHANGELOG.md`](CHANGELOG.md) — release history, starting with the 1.0.0 ground-up rewrite.
+- [`MIGRATION.md`](MIGRATION.md) — step-by-step upgrade guide from the 0.x Rails-engine era.
+- [`AGENTS.md`](AGENTS.md) — context for AI coding assistants; also a useful conventions-and-extension guide for human contributors.
+- [`docs/`](docs/) — topic-split deep dives on architecture, components, interfaces, data models, workflows, and dependencies. Start with [`docs/index.md`](docs/index.md).
 
 ## Contributing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,218 @@
+# Architecture
+
+## Design goals
+
+1. **One process, foreground, supervisor-driven.** No PID files, no `daemonize`, no `start`/`stop`/`restart` subcommands. The CLI has `run` only; `systemd`/`docker`/`launchd` own the lifecycle. This was a deliberate simplification in the 1.0 rewrite.
+2. **Two concurrent threads, one exit path.** A polling thread and an HTTP server thread. Both feed failures into a shared `Queue` that unblocks the main thread to drive graceful shutdown. No watchdog, no restart logic — if either thread can't keep going, the process exits and the supervisor restarts.
+3. **Write-path and read-path are fully decoupled via Mongo.** The Poller writes samples + snapshots. The HTTP server reads them. Neither holds a live reference to the other's data structures beyond a few class-level attrs (`HttpApp.poller` is read for metrics counters, not for call-through).
+4. **Structural separation between "current state" and "time series".** Two MongoDB collections, two Mongoid models, two query modules. See `data_models.md`.
+5. **Config is immutable at boot.** `Data.define` Config, validated once in `from_env`, never mutated. Changing anything requires a restart. Justified by the operational model (supervisor-driven, cheap to restart).
+6. **Library code logs structurally, never to stderr directly.** One logger module; everything else calls it. See `components.md` for the logger contract.
+
+## The two-thread model
+
+```mermaid
+sequenceDiagram
+    participant Main as Main thread
+    participant Queue as @stop: Queue
+    participant Poller as Poller thread
+    participant Puma as Puma thread
+    participant Miners as cgminer instances
+    participant Mongo as MongoDB
+
+    Main->>Main: install_signal_handlers (SIGTERM/SIGINT → @stop)
+    Main->>Main: Mongoid.configure, bootstrap collections
+    Main->>Poller: Thread.new { poller.run_until_stopped }
+    Main->>Puma: Thread.new { puma_launcher.run }
+    Main->>Main: reinstall_signal_handlers (after Puma's setup_signals)
+    Main->>Queue: @stop.pop (blocks)
+
+    loop every CGMINER_MONITOR_INTERVAL
+        Poller->>Miners: MinerPool.query(summary/devs/pools/stats)
+        Miners-->>Poller: responses (per-miner PoolResult)
+        Poller->>Mongo: insert_many samples + bulk_write snapshots
+    end
+
+    Puma->>Puma: serve /v2/* requests
+    Note over Puma: concurrent; isolated from Poller
+
+    Note over Main: SIGTERM arrives
+    Main->>Queue: signal pushed
+    Queue-->>Main: pop returns signal
+    Main->>Poller: poller.stop (signals @cv, sets @stopped=true)
+    Poller-->>Main: thread exits via loop condition
+    Main->>Main: poller_thread.join(shutdown_timeout)
+    Main->>Puma: puma_launcher.stop
+    Puma-->>Main: thread exits
+    Main->>Main: puma_thread.join(shutdown_timeout)
+    Main->>Main: exit 0
+```
+
+## Why signal handling is fiddly
+
+The file to look at is `lib/cgminer_monitor/server.rb`. Three subtleties:
+
+1. **`install_signal_handlers` must run before `Puma::Launcher.run`.** Puma's `setup_signals` synchronously overwrites process-wide signal handlers. If we install ours later, Puma silently takes our SIGTERM/SIGINT.
+
+2. **`raise_exception_on_sigterm false`.** By default, Puma raises `SignalException` on SIGTERM, which would bubble out of the Puma thread. We own shutdown, not Puma, so we disable that.
+
+3. **`reinstall_signal_handlers` runs after launcher start.** Even with `raise_exception_on_sigterm false`, Puma installs other handlers (USR1, USR2, HUP) that can stomp on what we want. We `sleep 0.05` to let Puma's thread finish `setup_signals`, then re-install the two we care about. It's a brief handoff race; the sleep is a heuristic compromise, not a correctness guarantee.
+
+**Consequence:** If anyone changes how the Server starts or stops Puma, they need to re-check that SIGTERM still reliably routes through our `@stop` queue rather than raising in Puma.
+
+## Graceful shutdown, concretely
+
+```mermaid
+graph TD
+    A[SIGTERM or SIGINT received] --> B[handler pushes signal to Queue]
+    B --> C[Main thread pops from Queue]
+    C --> D[Logger.info 'server.stopping']
+    D --> E[poller.stop — sets stopped and signals CV]
+    E --> F[poller_thread.join with shutdown_timeout]
+    F -->|exits cleanly| G[puma_launcher.stop]
+    F -.timeout.- G
+    G --> H[puma_thread.join with shutdown_timeout]
+    H -->|exits cleanly| I[Logger.info 'server.stopped']
+    H -.timeout.- I
+    I --> J[return exit code 0]
+
+    K[Puma crash in thread] -->|caught| L[push 'puma_crash' to Queue]
+    L --> C
+
+    M[Unexpected StandardError in Server.run] -->|caught| N[Logger.error 'server.crash']
+    N --> O[return exit code 1]
+```
+
+The shutdown path is bounded: if the poller takes longer than `CGMINER_MONITOR_SHUTDOWN_TIMEOUT` (default 10s) to clean up, we move on. Worst case, a mid-flight `insert_many` gets killed by the supervisor.
+
+## The Poller's interruptible sleep
+
+`Poller#run_until_stopped` runs an iteration, measures how long it took, then sleeps the remainder of the interval. The sleep uses a `ConditionVariable`:
+
+```ruby
+def interruptible_sleep(seconds)
+  @mutex.synchronize do
+    @cv.wait(@mutex, seconds) unless @stopped
+  end
+end
+```
+
+`Poller#stop` synchronizes on the same mutex, sets `@stopped = true`, and `@cv.signal`s. The sleeping thread wakes immediately instead of waiting out the rest of the interval. Without this, a shutdown during a long poll cycle could stall for up to a full interval.
+
+## Request lifecycle (write path)
+
+```mermaid
+sequenceDiagram
+    participant Poller
+    participant MinerPool as CgminerApiClient::MinerPool
+    participant Miners as Each Miner thread
+    participant CgMiner as cgminer
+    participant Sample
+    participant Snapshot
+    participant Mongo
+
+    loop each of [summary, devs, pools, stats]
+        Poller->>MinerPool: pool.query(command)
+        par one thread per miner
+            MinerPool->>Miners: Thread.new { miner.query(command) }
+            Miners->>CgMiner: TCP JSON request
+            CgMiner-->>Miners: response
+            Miners-->>MinerPool: MinerResult.success/failure
+        end
+        MinerPool-->>Poller: PoolResult
+    end
+
+    Poller->>Poller: extract numeric fields → sample rows
+    Poller->>Poller: build snapshot upsert ops
+    Poller->>Poller: append synthetic 'poll' samples (ok, duration_ms)
+
+    Poller->>Sample: collection.insert_many(all_samples)
+    Poller->>Snapshot: collection.bulk_write(snapshot_ops, ordered: false)
+    Sample->>Mongo: (time-series insert)
+    Snapshot->>Mongo: (upsert many)
+
+    Poller->>Poller: Logger.info 'poll.complete'
+```
+
+**Key observations:**
+- `extract_samples` normalizes keys (`"GHS 5s"` → `ghs_5s`, `"Pool Rejected%"` → `pool_rejected_pct`) and only keeps numeric values. String fields (device status, pool URL) are dropped from the samples collection but preserved in full in `latest_snapshot`.
+- Each miner also emits two synthetic per-poll samples: `{command: 'poll', metric: 'ok', v: 0|1}` and `{command: 'poll', metric: 'duration_ms', v: ...}`. These drive the availability graph and the Prometheus `cgminer_available` gauge.
+- `bulk_write(..., ordered: false)` means snapshot upserts don't short-circuit on the first failure — each miner's snapshot has an independent chance to succeed.
+- Errors at Mongo level are logged and counted; they don't re-raise out of `poll_once`. So a transient Mongo outage degrades polling silently (stats recorded in `polls_failed`) rather than crashing the process.
+
+## Request lifecycle (read path)
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Puma
+    participant HttpApp as Sinatra HttpApp
+    participant SampleQ as SampleQuery
+    participant SnapshotQ as SnapshotQuery
+    participant Sample
+    participant Snapshot
+    participant Mongo
+
+    Client->>Puma: GET /v2/graph_data/hashrate?since=1h
+    Puma->>HttpApp: route dispatch
+    HttpApp->>HttpApp: parse_time_range
+    HttpApp->>SampleQ: hashrate(miner:, since:, until_:)
+    SampleQ->>Sample: Sample.where(ts: ..., 'meta.command' => 'summary', ...)
+    Sample->>Mongo: query
+    Mongo-->>Sample: samples
+    SampleQ->>SampleQ: group_by ts, compute per-metric aggregates
+    SampleQ-->>HttpApp: [[ts, ghs_5s, ghs_av, ...], ...]
+    HttpApp-->>Client: JSON response
+
+    Client->>Puma: GET /v2/miners/192.168.1.10%3A4028/summary
+    Puma->>HttpApp: route dispatch
+    HttpApp->>HttpApp: CGI.unescape miner param, verify in configured_miners
+    HttpApp->>SnapshotQ: for_miner(miner:, command: 'summary')
+    SnapshotQ->>Snapshot: Snapshot.where(miner:, command:).first
+    Snapshot->>Mongo: query
+    Mongo-->>Snapshot: latest doc
+    Snapshot-->>SnapshotQ: Snapshot
+    SnapshotQ-->>HttpApp: Snapshot
+    HttpApp-->>Client: JSON with fetched_at, ok, response, error
+```
+
+**Key observations:**
+- The read path never hits cgminer directly. Everything it returns was written by the Poller at the last poll interval.
+- `HttpApp.configured_miners_cache` is lazily built on first access from `Config.current.miners_file`. It's frozen; only cleared via `HttpApp.reset_configured_miners!` (tests only).
+- Time-range parameters accept ISO-8601 or relative (`1h`, `30m`, `7d`, `2w`). Defaults to the last hour.
+- `Cache-Control: public, max-age=<interval>` is set on graph data responses so intermediate caches don't hammer Mongo.
+- `miner_snapshot` validates that the `:miner` path param exists in `configured_miners_cache` and returns 404 if not — an unknown miner ID can't even check the db.
+
+## HTTP API surface summary
+
+All under `/v2/*`. See `interfaces.md` for the full contract.
+
+- **`/healthz`** — returns one of `starting` / `healthy` / `degraded` plus diagnostics. HTTP 200 for healthy and starting, 503 for degraded.
+- **`/metrics`** — Prometheus text exposition. Reads from `latest_snapshot` for gauges and from `HttpApp.poller` for counters.
+- **`/miners`** — list of configured miners with availability inferred from the most recent snapshot.
+- **`/miners/:miner/{summary,devices,pools,stats}`** — latest snapshot per miner, per command.
+- **`/graph_data/{hashrate,temperature,availability}`** — time-range series queries.
+- **`/openapi.yml`** + **`/docs`** — OpenAPI 3.1 spec file and a Swagger UI front-end.
+
+## Design patterns
+
+### Config as a `Data.define`
+`CgminerMonitor::Config` is an immutable value object with 14 fields, built once from `ENV`, validated in `validate!`, and cached at module level via `Config.current`. This is deliberately not an `attr_accessor`-based config class — the whole point is that it can't change under anyone's feet.
+
+### Structured logging, no stderr
+`CgminerMonitor::Logger` is a module-singleton logger that writes JSON lines (or a human-readable `text` variant) to `$stdout`. It's thread-safe via a `Mutex`. Every log call passes keyword arguments, not a message string. Every event has an `event:` name for grep-ability. No class in the app calls `warn` or `puts` directly — the supervisor/systemd/docker consumes the structured log stream from stdout.
+
+### Queue-driven shutdown
+A shared `Queue` is the rendezvous point for "time to stop." Signal handlers push to it; Puma's crash handler pushes to it; the main thread blocks on it. This replaces the more common but more error-prone pattern of `Thread.current.raise` or `Thread#kill`.
+
+### Class-level state on HttpApp (deliberate, constrained)
+`HttpApp.poller`, `HttpApp.started_at`, `HttpApp.configured_miners_cache` are set by `Server` at boot, read by Sinatra routes. This is less clean than dependency injection but sidesteps the awkwardness of passing per-request context into Sinatra's class-level `get '...' do ... end` blocks. The trade-off: tests must reset that state between examples (see `spec/support/` and `HttpApp.reset_configured_miners!`).
+
+### "extract_samples" as a leaf function
+`Poller#extract_samples` is the one place that knows about cgminer's response shape (envelope → command-key → array of hash rows → numeric fields). Adding a new extracted metric or a new command means editing that one method. See the AGENTS.md extension notes.
+
+### Bypass pattern for cgminer_api_client's MinerPool
+`CgminerApiClient::MinerPool.new` hard-codes `'config/miners.yml'` relative to CWD. That doesn't honor monitor's `CGMINER_MONITOR_MINERS_FILE`. So `Poller#build_miner_pool` uses `MinerPool.allocate` and sets `.miners=` directly. It's an intentional escape hatch; if api_client ever grows a constructor that accepts a path, we can delete that ceremony.
+
+### OpenAPI as source of truth, enforced by CI
+`spec/openapi_consistency_spec.rb` walks `HttpApp`'s registered routes and cross-checks them against `lib/cgminer_monitor/openapi.yml`. Drift fails CI. The OpenAPI doc is packaged with the gem and served at `/openapi.yml`; `/docs` embeds Swagger UI.

--- a/docs/codebase_info.md
+++ b/docs/codebase_info.md
@@ -1,0 +1,153 @@
+# Codebase Info
+
+## What this is
+
+`cgminer_monitor` is a standalone Ruby daemon (**not** a Rails engine anymore, as of the 1.0 rewrite in April 2026) that periodically polls [cgminer](https://github.com/ckolivas/cgminer) instances over their JSON API, stores device/pool/summary/stats data in MongoDB, and exposes a read-only HTTP API for querying historical and current miner state.
+
+It ships as both a gem (so operators can `gem install cgminer_monitor` and get a `cgminer_monitor` executable) and a Docker image (multi-stage `Dockerfile` plus `docker-compose.yml`). It is **not** a library-first gem — nobody should be `require 'cgminer_monitor'`-ing it from their own code. It is invoked exclusively through its CLI.
+
+At runtime the process has two threads:
+- **Poller** — runs one iteration per `CGMINER_MONITOR_INTERVAL` seconds, fans out cgminer commands across every configured miner via `CgminerApiClient::MinerPool`, extracts numeric metrics, and writes time-series samples + latest-state snapshots to Mongo.
+- **HTTP server** — an embedded Puma serving a Sinatra app on `CGMINER_MONITOR_HTTP_PORT` (default `9292`). Read-only; serves `/v2/*` API endpoints, Prometheus metrics, and Swagger UI.
+
+## Stack
+
+- **Language:** Ruby 3.2+ (gemspec `required_ruby_version`).
+- **CI matrix:** Ruby 3.2/3.3/3.4 required × Mongo 6/7. Ruby 4.0 and `head` are best-effort (Mongoid 9 doesn't officially support them yet).
+- **Storage:** MongoDB 5.0+. 5.0 is the minimum for time-series collections; 6.0 is what the GitHub Actions matrix tests against because it's the earliest Mongo version available in `services:` runners.
+- **Runtime gem deps:** `cgminer_api_client ~> 0.3.0`, `mongoid ~> 9.0`, `sinatra >= 4.0`, `puma >= 6.0`, `rack-cors ~> 2.0`.
+- **Dev deps:** `rspec >= 3.13`, `rack-test >= 2.1`, `rubocop >= 1.60` (+ `-rake`, `-rspec`), `rake >= 13.2`, `simplecov >= 0.22`.
+- **Test framework:** RSpec. Unit specs at `spec/cgminer_monitor/**`, integration specs at `spec/integration/`, plus a top-level `spec/openapi_consistency_spec.rb` that CI uses to enforce route↔openapi.yml parity.
+- **Lint:** RuboCop with `TargetRubyVersion: 3.2`. Default rake task runs spec + rubocop.
+- **Coverage:** SimpleCov, filter `/spec/`; reports to `coverage/`.
+- **Containerization:** Dockerfile (multi-stage, `ruby:3.4-slim` base) and `docker-compose.yml` (Mongo + cgminer_monitor + optional FakeCgminer for testing).
+
+## Directory layout
+
+```
+cgminer_monitor/
+├── bin/
+│   └── cgminer_monitor              # CLI: run / migrate / doctor / version
+├── lib/
+│   ├── cgminer_monitor.rb           # Entry point: require graph only
+│   └── cgminer_monitor/
+│       ├── config.rb                # Data.define Config, from_env, validate!, current/reset! helpers
+│       ├── errors.rb                # Error < StandardError, ConfigError, StorageError, PollError
+│       ├── logger.rb                # Structured JSON/text logger (module singleton, thread-safe)
+│       ├── sample.rb                # Mongoid time-series model (samples collection)
+│       ├── sample_query.rb          # Read-side module: hashrate, temperature, availability series
+│       ├── snapshot.rb              # Mongoid regular model (latest_snapshot collection)
+│       ├── snapshot_query.rb        # Read-side: for_miner, miners, last_poll_at
+│       ├── poller.rb                # Polling loop, sample extraction, bulk writes
+│       ├── server.rb                # Orchestrator: Mongoid config, Poller thread, Puma thread, signal handling
+│       ├── http_app.rb              # Sinatra app: /v2/* endpoints, Prometheus, /docs, /openapi.yml
+│       ├── openapi.yml              # OpenAPI 3.1 spec (served at /openapi.yml, lint-checked in CI)
+│       └── version.rb               # VERSION = "1.0.0"
+├── spec/
+│   ├── spec_helper.rb               # SimpleCov + require_relative support/**
+│   ├── cgminer_monitor_spec.rb
+│   ├── cgminer_monitor/             # Unit specs, one per lib/ file
+│   ├── integration/
+│   │   ├── cli_spec.rb              # Spawns the real bin/ via Open3
+│   │   ├── full_pipeline_spec.rb    # FakeCgminer + Poller + Mongo + HttpApp end-to-end
+│   │   └── healthz_spec.rb          # State transitions: starting → healthy → degraded
+│   ├── openapi_consistency_spec.rb  # CI guard: routes vs openapi.yml
+│   └── support/
+│       ├── cgminer_fixtures.rb      # Canned cgminer JSON responses (shared with cgminer_api_client)
+│       ├── fake_cgminer.rb          # In-process TCP cgminer server (shared with cgminer_api_client)
+│       └── mongo_helper.rb          # Test Mongo config + per-spec db reset
+├── config/
+│   └── miners.yml.example           # Ships in the gem; operator copies to config/miners.yml
+├── .github/workflows/ci.yml         # Lint, Test matrix, Integration, OpenAPI consistency jobs
+├── Dockerfile                       # Multi-stage: builder (build-essential) → runtime (ruby:3.4-slim)
+├── docker-compose.yml               # mongo + cgminer_monitor + optional fake_cgminer under "testing" profile
+├── .rubocop.yml
+├── .rspec                           # --color --warnings --require spec_helper (implicit)
+├── .ruby-version                    # local dev pin
+├── Rakefile                         # default: [spec, rubocop]
+├── Gemfile
+├── cgminer_monitor.gemspec
+├── CHANGELOG.md                     # Keep-a-Changelog; 1.0.0 release notes
+├── MIGRATION.md                     # 0.x → 1.0 migration guide for cgminer_manager consumers
+├── README.md
+└── LICENSE.txt                      # MIT
+```
+
+Files packaged in the gem (via the gemspec `spec.files` glob): `lib/**/*.rb`, `lib/**/*.yml` (the OpenAPI spec), `bin/*`, `README.md`, `LICENSE.txt`, `CHANGELOG.md`, `cgminer_monitor.gemspec`. Notably **not** packaged: `spec/`, `config/miners.yml.example` (deliberately — the docker-compose assumes the operator mounts their own), `docs/`, `.github/`, `Dockerfile`, `docker-compose.yml`, `MIGRATION.md`.
+
+## Languages and tooling
+
+| | |
+|---|---|
+| Primary language | Ruby |
+| Other languages | None (the Dockerfile is the closest thing to non-Ruby config) |
+| Build tool | `bundler` (gem), `rake` (default task), `docker` (container image) |
+| Package format | RubyGem (`.gem`) + Docker image |
+| Distribution | [RubyGems.org](https://rubygems.org/gems/cgminer_monitor) and Docker Hub / GHCR (if published) |
+
+## High-level module graph
+
+```mermaid
+graph TB
+    CLI[bin/cgminer_monitor]
+    Config[CgminerMonitor::Config]
+    Server[CgminerMonitor::Server]
+    Poller[CgminerMonitor::Poller]
+    HttpApp[CgminerMonitor::HttpApp]
+    Puma[Puma::Launcher]
+    Logger[CgminerMonitor::Logger]
+    Sample[CgminerMonitor::Sample]
+    Snapshot[CgminerMonitor::Snapshot]
+    SampleQ[CgminerMonitor::SampleQuery]
+    SnapshotQ[CgminerMonitor::SnapshotQuery]
+    APIClient[CgminerApiClient::MinerPool]
+    Mongo[(MongoDB)]
+    Cgminer[cgminer instances]
+
+    CLI -->|run| Server
+    CLI -->|migrate| Sample
+    CLI -->|migrate| Snapshot
+    CLI -->|doctor| Config
+    CLI -->|doctor| APIClient
+
+    Server -->|Mongoid.configure| Mongo
+    Server -->|spawns| Poller
+    Server -->|spawns| Puma
+    Puma -->|hosts| HttpApp
+
+    Poller -->|queries| APIClient
+    APIClient -->|TCP| Cgminer
+    Poller -->|insert_many| Sample
+    Poller -->|bulk_write| Snapshot
+
+    HttpApp -->|reads via| SampleQ
+    HttpApp -->|reads via| SnapshotQ
+    HttpApp -.reads class attr.-> Poller
+    SampleQ -->|queries| Sample
+    SnapshotQ -->|queries| Snapshot
+
+    Sample -->|persists to| Mongo
+    Snapshot -->|persists to| Mongo
+
+    Poller -.-> Logger
+    Server -.-> Logger
+    HttpApp -.-> Logger
+```
+
+## Key facts worth knowing up front
+
+1. **Two threads, one process.** Poller and Puma run concurrently in the same Ruby process. Shutdown coordinates both; see `architecture.md`.
+2. **`Config` is immutable** (`Data.define`). No hot reload. Changing env vars requires a restart.
+3. **Mongoid is configured programmatically** from `CGMINER_MONITOR_MONGO_URL` — there is no `config/mongoid.yml` in 1.0.
+4. **`miners.yml` is loaded at boot** and frozen. Adding/removing miners requires a restart.
+5. **`HttpApp` has class-level state** (`.poller`, `.started_at`, `.configured_miners_cache`) set by `Server` at boot. Tests must call `HttpApp.reset_configured_miners!` between examples.
+6. **The samples collection is a MongoDB time-series collection** (Mongo 5.0+ feature) with an `expire_after` TTL matching `CGMINER_MONITOR_RETENTION_SECONDS`. `cgminer_monitor migrate` (or `Server#bootstrap_mongoid!`) does the `create_collection` call.
+7. **No authentication on the HTTP API.** Designed for trusted networks. Put a reverse proxy in front of it if you're exposing it beyond that.
+8. **`cgminer_api_client` is a hard runtime dependency.** The `Poller` bypasses `CgminerApiClient::MinerPool.new` (which hard-codes a `config/miners.yml` path relative to CWD) by allocating the pool and setting `.miners=` directly, so it can honor the configurable `CGMINER_MONITOR_MINERS_FILE`.
+
+## Version and release posture
+
+- Current release: **1.0.0** (2026-04-15). Ground-up rewrite; see `CHANGELOG.md` and `MIGRATION.md`.
+- Semantic Versioning. The 1.0 release drew a line under 0.x's Rails-engine shape.
+- `rubygems_mfa_required` set in gemspec metadata.
+- `Gemfile.lock` is `.gitignore`d — this gem expects consumers to generate their own.

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,234 @@
+# Components
+
+Every major component lives in a single file under `lib/cgminer_monitor/`. The composition is flat: no service locator, no factories, no DI container. Components either are immutable value objects (`Config`), Mongoid models (`Sample`, `Snapshot`), module-singletons (`Logger`, `SampleQuery`, `SnapshotQuery`), or plain classes owning one concern (`Poller`, `Server`, `HttpApp`).
+
+## Component map
+
+```mermaid
+graph LR
+    subgraph cgminer_monitor_rb["cgminer_monitor.rb"]
+        Mod[module CgminerMonitor]
+    end
+    subgraph errors_rb["errors.rb"]
+        ErrClasses[Error hierarchy]
+    end
+    subgraph version_rb["version.rb"]
+        Ver[VERSION]
+    end
+    subgraph config_rb["config.rb"]
+        Cfg[Config]
+    end
+    subgraph logger_rb["logger.rb"]
+        Log[Logger module singleton]
+    end
+    subgraph sample_rb["sample.rb"]
+        Smp[Sample]
+    end
+    subgraph snapshot_rb["snapshot.rb"]
+        Snp[Snapshot]
+    end
+    subgraph sample_query_rb["sample_query.rb"]
+        SmpQ[SampleQuery]
+    end
+    subgraph snapshot_query_rb["snapshot_query.rb"]
+        SnpQ[SnapshotQuery]
+    end
+    subgraph poller_rb["poller.rb"]
+        Pol[Poller]
+    end
+    subgraph server_rb["server.rb"]
+        Srv[Server]
+    end
+    subgraph http_app_rb["http_app.rb"]
+        App[HttpApp]
+    end
+
+    Srv -->|owns| Pol
+    Srv -->|sets class attrs on| App
+    Pol -->|writes| Smp
+    Pol -->|writes| Snp
+    App -->|reads via| SmpQ
+    App -->|reads via| SnpQ
+    SmpQ -->|queries| Smp
+    SnpQ -->|queries| Snp
+    Pol -.logs.-> Log
+    Srv -.logs.-> Log
+    App -.logs.-> Log
+    Pol -->|raises| ErrClasses
+    Cfg -->|raises| ErrClasses
+    Cfg -.reads env-.-> Srv
+```
+
+## Component list
+
+### `CgminerMonitor` (module)
+**File:** `lib/cgminer_monitor.rb`
+
+Top-level namespace. The file is only `require` statements for the other files plus an empty `module CgminerMonitor; end`. Loads, in order: `cgminer_api_client`, `mongoid`, then the gem's own modules in dependency order.
+
+### `CgminerMonitor::Error` and siblings
+**File:** `lib/cgminer_monitor/errors.rb`
+
+Four exception classes:
+- `Error < StandardError` — gem base.
+- `ConfigError < Error` — raised by `Config#validate!` and from `bin/cgminer_monitor` when env vars fail parsing.
+- `StorageError < Error` — reserved for Mongo-layer failures we want the app to treat specially. Currently declared but not raised (Mongo errors are caught at the Poller level and logged without being rewrapped).
+- `PollError < Error` — reserved for polling-layer failures. Currently declared but not raised.
+
+### `CgminerMonitor::Config` (`Data.define`)
+**File:** `lib/cgminer_monitor/config.rb`
+
+Immutable 14-field value object built from ENV. Fields: `interval`, `retention_seconds`, `mongo_url`, `http_host`, `http_port`, `http_min_threads`, `http_max_threads`, `miners_file`, `log_format`, `log_level`, `cors_origins`, `shutdown_timeout`, `healthz_stale_multiplier`, `healthz_startup_grace_seconds`.
+
+Public surface:
+- `Config.from_env(env = ENV)` — build + validate in one call. Raises `ConfigError` on bad values.
+- `Config.current` — memoized `from_env` result for code paths that want a global handle (primarily `HttpApp`). `Config.reset!` clears the memo (tests only).
+- `#validate!` — runs sanity checks: `interval > 0`, `log_format ∈ {json, text}`, `miners_file` exists, `log_level ∈ {debug, info, warn, error}`.
+- `#public_attrs` — `to_h` with the mongo URL redacted (`mongodb://user:pass@host` → `mongodb://[REDACTED]@host`). Used for logging and `doctor` output.
+
+Any constructor field that fails parsing surfaces as a `ConfigError` at boot time, which the CLI translates into exit `78` (`EX_CONFIG`).
+
+### `CgminerMonitor::Logger` (module singleton)
+**File:** `lib/cgminer_monitor/logger.rb`
+
+Thread-safe module-level structured logger. Writes to `$stdout` by default (overridable via `Logger.output=` for tests).
+
+Public surface:
+- `Logger.info(**fields)`, `.warn`, `.error`, `.debug` — keyword-only. Every call gets `ts` (ISO-8601 with millis) and `level` automatically merged in. The convention is that every event has an `event:` key naming it (`'poll.complete'`, `'server.stopping'`, `'healthz.mongo_unreachable'`).
+- `Logger.format=` — `"json"` (default) writes one JSON object per line; `"text"` writes `ts LEVEL event k=v k=v` for humans.
+- `Logger.level=` — `"debug"`, `"info"`, `"warn"`, `"error"`. Lines below the configured level are dropped.
+
+Locking is via an internal `Mutex`, so concurrent writes from the Poller thread and the Puma thread don't interleave within a single line.
+
+### `CgminerMonitor::Sample` (Mongoid document)
+**File:** `lib/cgminer_monitor/sample.rb`
+
+Mongoid model for the `samples` MongoDB time-series collection. Three fields: `ts` (Time), `meta` (Hash with `miner`, `command`, `sub`, `metric`), and `v` (Float).
+
+Crucially, `store_in` is **not** called as a class macro here — it's invoked programmatically by `Server#bootstrap_mongoid!` (or by `cgminer_monitor migrate`) with runtime collection options (the `expire_after` TTL depends on `Config#retention_seconds`, which doesn't exist at class-load time). This is also why `create_collection` has to be called explicitly: Mongoid's lazy-create would make a regular collection instead of a time-series one.
+
+### `CgminerMonitor::Snapshot` (Mongoid document)
+**File:** `lib/cgminer_monitor/snapshot.rb`
+
+Mongoid model for the `latest_snapshot` regular collection. Fields: `miner` (String), `command` (String), `fetched_at` (Time), `ok` (Boolean), `response` (Hash), `error` (String).
+
+Two indexes:
+- `{miner: 1, command: 1}` **unique** — enforces one doc per miner+command. Every poll upserts against this compound key.
+- `{fetched_at: 1}` — supports "most recently polled" queries for healthz and metrics.
+
+`store_in collection: "latest_snapshot"` is a class macro here (not parameterized like `Sample`), since this is a plain collection.
+
+### `CgminerMonitor::SampleQuery` (module)
+**File:** `lib/cgminer_monitor/sample_query.rb`
+
+Read-side module. Three public methods:
+- `hashrate(miner: nil, since: nil, until_: nil)` — returns `[[ts, ghs_5s, ghs_av, device_hardware_pct, device_rejected_pct, pool_rejected_pct, pool_stale_pct], ...]`. Pool-wide when `miner` is nil (aggregated via sum or mean depending on the metric).
+- `temperature(miner: nil, since: nil, until_: nil)` — returns `[[ts, min, avg, max], ...]` per ts from `devs`/`stats` samples whose metric name matches `/^temp/`.
+- `availability(miner: nil, since: nil, until_: nil)` — per-miner: `[[ts, 0|1], ...]`. Pool-wide: `[[ts, available_count, configured_count], ...]`.
+
+Defaults the time range to the last hour when `since`/`until_` are nil.
+
+### `CgminerMonitor::SnapshotQuery` (module)
+**File:** `lib/cgminer_monitor/snapshot_query.rb`
+
+Read-side module. Three public methods:
+- `for_miner(miner:, command:)` — returns the single `Snapshot` matching the compound key, or nil.
+- `miners` — runs a Mongo aggregation pipeline to collapse snapshots by miner, returning `[{miner:, fetched_at:, ok:}, ...]` where `ok` is "any command succeeded in the most recent poll."
+- `last_poll_at(miner:)` — the most recent `fetched_at` across all commands for that miner.
+
+### `CgminerMonitor::Poller`
+**File:** `lib/cgminer_monitor/poller.rb`
+
+The write side. Three responsibilities: orchestrate a poll cycle, extract samples from cgminer responses, and persist to Mongo.
+
+Public surface:
+- `initialize(config, miner_pool: nil)` — `miner_pool` injectable for tests; otherwise built from `config.miners_file`.
+- `poll_once` — one full iteration: query every miner for each of `[summary, devs, pools, stats]`, build sample rows + snapshot upserts, write them in bulk, log `'poll.complete'`. Catches `Mongo::Error` and general `StandardError` so one failure doesn't kill the thread.
+- `run_until_stopped(_stop_channel)` — loop invoking `poll_once`, sleeping the remaining interval via the interruptible condvar.
+- `stop` — signals the condvar so the sleep exits immediately; sets `@stopped = true`.
+- `stopped?`, `polls_ok`, `polls_failed` — state introspection for `HttpApp`.
+
+Private surface worth noting:
+- `extract_samples(miner_id, command, response, ts)` — the leaf function that knows cgminer's response shape. Extend here to record a new metric.
+- `normalize_metric(field)` — lowercases, replaces spaces with underscores, maps `%` to `_pct`. Turns `"Pool Rejected%"` into `pool_rejected_pct`.
+- `build_miner_pool(miners_file)` — the `CgminerApiClient::MinerPool.allocate` + manual `.miners=` dance that honors a configurable miners path.
+
+### `CgminerMonitor::Server`
+**File:** `lib/cgminer_monitor/server.rb`
+
+Orchestrator. `Server#run` is the `cgminer_monitor run` entry point and returns an exit code.
+
+Responsibilities:
+- Install SIGTERM/SIGINT handlers **before** Puma starts (and reinstall after, see `architecture.md`).
+- Configure Mongoid from `config.mongo_url`.
+- `validate_startup!` — verify `miners.yml` parses non-empty and Mongo is reachable (raises `ConfigError` on empty, `Mongo::Error` on unreachable).
+- `bootstrap_mongoid!` — programmatic `store_in` + `create_collection` for `Sample`; `create_indexes` for `Snapshot`.
+- Wire up `HttpApp` class-level attrs (`.poller`, `.started_at`) for health-check and metrics access.
+- Spawn Poller and Puma threads; block on `@stop.pop`.
+- On signal: stop poller, `join` with shutdown timeout, stop launcher, `join` again, exit 0.
+- On `StandardError` in `run` body: log, exit 1. `ConfigError` from `validate_startup!` surfaces here — CLI translates any `ConfigError` to exit 78.
+
+Class-level attrs `Server.started_at` and `Server.poller` shadow the `HttpApp` ones (same values). Either could be removed without breaking behavior; both exist for historical reasons and symmetry.
+
+### `CgminerMonitor::HttpApp` (Sinatra::Base)
+**File:** `lib/cgminer_monitor/http_app.rb`
+
+The read side. Sinatra app mounted under Puma. All routes under `/v2/*`, plus `/openapi.yml` and `/docs`.
+
+Class-level state set by `Server` at boot:
+- `HttpApp.poller` — reference to the running `Poller` instance for metrics counters (`polls_ok`, `polls_failed`).
+- `HttpApp.started_at` — UTC Time, uptime source for `/healthz`.
+- `HttpApp.configured_miners_cache` — lazily-built frozen list of `[miner_id, host, port]` from `Config.current.miners_file`. Read by `/miners`, used to validate `:miner` path params.
+- `HttpApp.reset_configured_miners!` — test helper to clear the cache.
+
+Uses `Rack::Cors` middleware configured from `Config.current.cors_origins`. `show_exceptions` and `dump_errors` are off; a generic `error do` handler logs unhandled exceptions via `Logger.error` and returns `{"error": "internal"}` with HTTP 500. A `not_found` handler returns `{"error": "not found"}` with 404.
+
+Routes dispatch into `SampleQuery`/`SnapshotQuery` for everything read-shaped; the Prometheus endpoint builds its output from `Snapshot` queries directly plus `poller`'s counters.
+
+### OpenAPI spec file
+**File:** `lib/cgminer_monitor/openapi.yml`
+
+OpenAPI 3.1 document. Packaged in the gem (the gemspec includes `lib/**/*.yml`), served at `/openapi.yml`, and asserted against `HttpApp`'s registered routes by `spec/openapi_consistency_spec.rb`. Adding or removing a route requires updating this file in the same commit.
+
+## CLI
+
+### `bin/cgminer_monitor`
+**File:** `bin/cgminer_monitor`
+
+Subcommand dispatcher. Four real commands and four deprecated shims from the 0.x Daemon-based world:
+
+| Subcommand | Does |
+|---|---|
+| `run` | `Config.from_env` → `Server.new(config).run` → exit with its return code |
+| `migrate` | Configure Mongoid, `Sample.store_in`, `Sample.create_collection`, `Snapshot.create_indexes`. Idempotent. |
+| `doctor` | Print config, test Mongo connectivity, test each miner's `version` command. Diagnostic only. |
+| `version` / `-v` / `--version` | Print `cgminer_monitor <VERSION>` |
+| `start` | Deprecated: prints "did you mean 'run'?" and exits 64 |
+| `restart` | Deprecated: "did you mean 'run'?" exit 64 |
+| `status` | Deprecated: "did you mean 'doctor'?" exit 64 |
+| `stop` | Deprecated: "Process management is now handled by your supervisor." exit 64 |
+| any other | exits 64 with a usage hint |
+| (no argument) | prints usage block and exits 64 |
+
+Exit codes:
+- `0` — `run` completed cleanly.
+- `1` — `run` crashed, or `migrate` hit a Mongo error.
+- `64` — unknown command (`EX_USAGE`).
+- `78` — `ConfigError` at startup (`EX_CONFIG`).
+
+## Test-only components (not packaged in the gem)
+
+### `FakeCgminer`
+**File:** `spec/support/fake_cgminer.rb`
+
+Identical to the one in `cgminer_api_client` — an in-process TCP server that accepts a JSON request, looks up the command name in a fixtures hash, writes a canned response, and closes the socket. Used by `spec/integration/full_pipeline_spec.rb` to exercise the whole pipeline without real miners.
+
+### `CgminerFixtures`
+**File:** `spec/support/cgminer_fixtures.rb`
+
+Also identical to api_client's. Canned cgminer wire-format JSON responses keyed by command name.
+
+### `mongo_helper.rb`
+**File:** `spec/support/mongo_helper.rb`
+
+Configures Mongoid for the test database (reads `CGMINER_MONITOR_MONGO_URL` or defaults to `mongodb://localhost:27017/cgminer_monitor_test`), clears collections between examples, ensures the `samples` time-series collection exists before tests that need it.

--- a/docs/data_models.md
+++ b/docs/data_models.md
@@ -1,0 +1,216 @@
+# Data Models
+
+cgminer_monitor stores two kinds of thing in MongoDB: **samples** (time-series of numeric metrics) and **latest_snapshot** (most recent cgminer response per miner per command). Nothing else is persisted. In-memory, there's also the immutable `Config` value object and the `Error` hierarchy.
+
+## Persistent models
+
+### `CgminerMonitor::Sample` → `samples` time-series collection
+
+MongoDB time-series collection (Mongo 5.0+ feature). Very thin Mongoid model.
+
+```mermaid
+classDiagram
+    class Sample {
+        <<time-series>>
+        +ts: Time
+        +meta: Hash
+        +v: Float
+    }
+    class meta_shape {
+        <<Hash contents>>
+        +miner: "host:port"
+        +command: "summary"|"devs"|"pools"|"stats"|"poll"
+        +sub: Integer
+        +metric: String
+    }
+    Sample --> meta_shape : has
+```
+
+**Collection-level shape** (set by `Server#bootstrap_mongoid!` or `cgminer_monitor migrate`):
+- `timeField: "ts"`
+- `metaField: "meta"`
+- `granularity: "minutes"` — optimizes internal bucketing for our ~1/minute write rate.
+- `expire_after: <retention_seconds>` — applied as a TTL via Mongo's time-series-native TTL support. Defaults to 30 days; set via `CGMINER_MONITOR_RETENTION_SECONDS`.
+
+**No indexes beyond the implicit time-series indexes.** Mongo manages them based on `timeField` + `metaField`.
+
+**Why `store_in` is called programmatically.** Two reasons: `expire_after` depends on runtime config that doesn't exist at class-load time, and Mongoid's lazy `create_collection` would produce a regular collection rather than a time-series one if we didn't call `create_collection` explicitly after configuring `store_in`. See the comment in `lib/cgminer_monitor/sample.rb`.
+
+**Sample row examples:**
+
+```ruby
+# A hashrate sample from a summary response
+{ ts: 2026-04-19 13:45:12 UTC,
+  meta: { miner: "192.168.1.10:4028", command: "summary", sub: 0, metric: "ghs_5s" },
+  v: 14000000.0 }
+
+# A temperature sample from a devs response
+{ ts: 2026-04-19 13:45:12 UTC,
+  meta: { miner: "192.168.1.10:4028", command: "devs", sub: 2, metric: "temperature" },
+  v: 65.0 }
+
+# A synthetic per-poll availability sample (metric: ok)
+{ ts: 2026-04-19 13:45:12 UTC,
+  meta: { miner: "192.168.1.10:4028", command: "poll", sub: 0, metric: "ok" },
+  v: 1.0 }
+
+# A synthetic per-poll duration sample
+{ ts: 2026-04-19 13:45:12 UTC,
+  meta: { miner: "192.168.1.10:4028", command: "poll", sub: 0, metric: "duration_ms" },
+  v: 142.3 }
+```
+
+**How keys get there (`Poller#normalize_metric`):**
+- Lowercase.
+- Spaces → underscores.
+- `%` → `_pct`.
+
+So `"MHS av"` → `mhs_av`, `"Pool Rejected%"` → `pool_rejected_pct`, `"Last Share Time"` → `last_share_time`.
+
+**Only numeric fields become samples.** Strings (device names, pool URLs, worker names) are silently skipped in `extract_samples` — but the full response (strings included) is still preserved in `latest_snapshot`.
+
+### `CgminerMonitor::Snapshot` → `latest_snapshot` regular collection
+
+Regular Mongoid collection. One doc per `(miner, command)` pair, upserted every poll.
+
+```mermaid
+classDiagram
+    class Snapshot {
+        <<document>>
+        +miner: String
+        +command: String
+        +fetched_at: Time
+        +ok: Boolean
+        +response: Hash?
+        +error: String?
+    }
+```
+
+**Fields:**
+- `miner` — `"host:port"` string.
+- `command` — one of `"summary"`, `"devs"`, `"pools"`, `"stats"`.
+- `fetched_at` — when the poll started.
+- `ok` — `true` if cgminer answered and the response parsed; `false` on connection failures or `STATUS=E/F`.
+- `response` — the full cgminer response hash (envelope + command data). Null when `ok` is false.
+- `error` — `"<ErrorClass>: <message>"` when `ok` is false. Null when `ok` is true.
+
+**Indexes:**
+- `{miner: 1, command: 1}` **unique** — enforces one doc per key pair. Drives the per-miner snapshot route.
+- `{fetched_at: 1}` — supports healthz's "oldest poll" check and the SnapshotQuery aggregations.
+
+**Why a regular collection rather than time-series:** `latest_snapshot` is write-heavy by upsert (one write per miner per command per poll cycle), and reads mostly look up single rows by compound key. Time-series wouldn't buy anything here.
+
+### Writes go in bulk, reads use simple criteria
+
+The Poller issues one `insert_many` per poll cycle for samples (potentially hundreds of rows) and one `bulk_write` with `ordered: false` for snapshots. `ordered: false` means one miner's snapshot upsert failing doesn't block the others.
+
+Reads use straightforward `Sample.where(...)` and `Snapshot.where(...)` criteria chains, with one raw aggregation pipeline in `SnapshotQuery.miners` for the "collapse snapshots per miner" projection.
+
+## In-memory models
+
+### `CgminerMonitor::Config` (`Data.define`)
+
+Immutable value object. Built from `ENV` via `Config.from_env` at boot, validated once, cached via `Config.current`.
+
+```mermaid
+classDiagram
+    class Config {
+        <<Data.define>>
+        +interval: Integer
+        +retention_seconds: Integer
+        +mongo_url: String
+        +http_host: String
+        +http_port: Integer
+        +http_min_threads: Integer
+        +http_max_threads: Integer
+        +miners_file: String
+        +log_format: String
+        +log_level: String
+        +cors_origins: String
+        +shutdown_timeout: Integer
+        +healthz_stale_multiplier: Integer
+        +healthz_startup_grace_seconds: Integer
+        +validate!() Config
+        +public_attrs() Hash
+        +redact_mongo_url(url)
+    }
+```
+
+**Invariants (enforced by `validate!`):**
+- `interval > 0`
+- `log_format ∈ {"json", "text"}`
+- `log_level ∈ {"debug", "info", "warn", "error"}`
+- `File.exist?(miners_file)`
+
+**`public_attrs`** returns `to_h` with `mongo_url` redacted (`mongodb://user:pass@host` → `mongodb://[REDACTED]@host`). Used by the log startup line and by `cgminer_monitor doctor`.
+
+**Immutable by design.** Config cannot be mutated at runtime. A config change requires a restart. Justified because the process model is supervisor-driven and a restart is cheap.
+
+### Error class hierarchy
+
+```mermaid
+classDiagram
+    StandardError <|-- Error
+    Error <|-- ConfigError
+    Error <|-- StorageError
+    Error <|-- PollError
+
+    class Error { <<CgminerMonitor::Error>> }
+    class ConfigError { raised by Config#validate! and env parsing }
+    class StorageError { declared, not raised }
+    class PollError { declared, not raised }
+```
+
+- `ConfigError` — raised on bad env values and missing `miners.yml`; CLI translates to exit 78.
+- `StorageError`, `PollError` — reserved for future use. Currently, Mongo errors (`Mongo::Error` from the driver) are caught at the `Poller` boundary and logged rather than rewrapped, and polling-layer errors from `cgminer_api_client` are caught and attached to failed `Snapshot` docs rather than rewrapped.
+
+### PoolResult and MinerResult (from `cgminer_api_client`)
+
+Not defined by this gem, but part of the data model that flows through it. `Poller#poll_miner` iterates `MinerResult` instances inside a `PoolResult`:
+
+```ruby
+pool_result  = @miner_pool.query('summary')   # → PoolResult
+miner_result = pool_result[miner_id]          # → MinerResult
+if miner_result&.ok?
+  response = miner_result.value.is_a?(Array) ? miner_result.value.first : miner_result.value
+  # extract samples, build snapshot upsert
+else
+  # attach error string to snapshot upsert
+end
+```
+
+See `cgminer_api_client/docs/data_models.md` in the sibling repo for that object shape.
+
+## Raw vs. stored response shape
+
+cgminer's wire format looks like this (after `cgminer_api_client` parses and normalizes it):
+
+```ruby
+{
+  status: [{ status: "S", when: 1700000000, code: 11, msg: "Summary", description: "cgminer 4.11.1" }],
+  summary: [{ elapsed: 12345, mhs_av: 56789.12, ghs_5s: 14000000.0, ... }],
+  id: 1
+}
+```
+
+`cgminer_api_client`'s convenience `summary`/`coin`/`config`/`version`/`check` methods unwrap the single-element array for you, but the Poller calls `pool.query('summary')` directly, which returns the envelope form. `Poller#process_success` handles both shapes:
+
+```ruby
+response = miner_result.value.is_a?(Array) ? miner_result.value.first : miner_result.value
+```
+
+The Poller also stores cgminer's **original** key casing in the `response` field of `latest_snapshot` (because it was parsed by api_client into sanitized, symbolized keys, then the response shape is a Hash of the whole envelope — effectively what comes off the wire). The **sanitized-then-lowercased-snake_case** keys only appear in the `samples` meta (via `normalize_metric`).
+
+This has a subtle implication for the Prometheus endpoint (`HttpApp#build_prometheus_metrics`): it defensively checks both casings when reading from `latest_snapshot`:
+```ruby
+ghs_5s = summary['GHS 5s'] || summary['ghs_5s']
+```
+So adding a new metric that has different casing in different cgminer versions is handled by trying both forms.
+
+## Why two collections instead of one
+
+Because the read patterns are totally different:
+- **"What's happening right now with miner X"** → one row lookup by `(miner, command)`. Regular collection with a unique compound index. Fast, cheap, always current.
+- **"What was my hashrate over the last 2 hours"** → many rows by time range, grouped by ts. Time-series collection with automatic bucketing and Mongo-managed indexes. Fast, bounded retention, scales out.
+
+Trying to serve both from one collection would either slow down graph queries (they'd scan enormous non-bucketed rows) or bloat snapshots (they'd carry all historical data). Separation was the single biggest structural call in the 1.0 rewrite.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,103 @@
+# Dependencies
+
+## Runtime dependencies
+
+From the gemspec:
+
+| Gem | Constraint | Purpose |
+|---|---|---|
+| `cgminer_api_client` | `~> 0.3.0` | Talks to cgminer over its JSON API. Used by `Poller` for the parallel fan-out and in `bin/cgminer_monitor doctor` for connectivity pings. |
+| `mongoid` | `~> 9.0` | MongoDB ODM. Configures the `default` client from `CGMINER_MONITOR_MONGO_URL`. Backs `Sample` and `Snapshot`. |
+| `sinatra` | `>= 4.0` | HTTP app framework. `HttpApp < Sinatra::Base`. |
+| `puma` | `>= 6.0` | HTTP server. Embedded via `Puma::Configuration` + `Puma::Launcher`. |
+| `rack-cors` | `~> 2.0` | CORS middleware. Configured from `CGMINER_MONITOR_CORS_ORIGINS`. |
+
+Plus the Ruby stdlib pieces: `json`, `socket`, `yaml`, `cgi/escape`, `time`.
+
+**One conditional dependency.** `Gemfile` adds `gem 'ostruct' if RUBY_VERSION >= '3.5'` because Ruby 4.0 moved `ostruct` out of default gems and Mongoid 9 hasn't caught up yet. This is a compatibility shim, not a feature dep — `ostruct` is used by Mongoid internals, not by our code.
+
+**Transitive deps worth knowing about.** Mongoid pulls in `mongo` (the BSON driver) and `bson`. Sinatra pulls in `rack` and `tilt`. Puma pulls in `nio4r`. None of these are used directly by our code.
+
+## Dev dependencies
+
+From `Gemfile`:
+
+```ruby
+group :development do
+  gem 'rack-test',     '>= 2.1'
+  gem 'rake',          '>= 13.2'
+  gem 'rspec',         '>= 3.13'
+  gem 'rubocop',       '>= 1.60'
+  gem 'rubocop-rake',  '>= 0.6'
+  gem 'rubocop-rspec', '>= 3.0'
+  gem 'simplecov',     '>= 0.22'
+end
+```
+
+| Gem | Used for |
+|---|---|
+| `rack-test` | HTTP app specs — provides `Rack::Test::Methods` for making synthetic requests against `HttpApp` without spinning up Puma. |
+| `rake` | Task runner. `Rakefile` defines `default: [spec, rubocop]` and `test: :spec`. |
+| `rspec` | Test framework. Unit + integration. |
+| `rubocop` | Linter. `.rubocop.yml` has `TargetRubyVersion: 3.2` and turns off most `Metrics/*` cops. |
+| `rubocop-rake` / `rubocop-rspec` | RuboCop plugin cops for Rake and RSpec styles. |
+| `simplecov` | Code coverage. Starts in `spec_helper.rb`. |
+
+## Ruby version support
+
+- **Minimum: Ruby 3.2.** Enforced by `spec.required_ruby_version = ">= 3.2"`. Data.define (used by `Config`) requires 3.2+.
+- **CI-tested: 3.2, 3.3, 3.4.** Must-pass.
+- **Best-effort: 4.0, head.** Allowed to fail in CI (`continue-on-error`). Mongoid 9 upstream only officially tests 3.3, so 3.4 parity is our assertion not theirs; 4.0 is even more speculative.
+- **Local dev pin:** `.ruby-version` (not shown here but present).
+
+**Why not higher floor?** Mongoid 9 supports Ruby 3.0+, `cgminer_api_client` requires 3.2+, `Data.define` requires 3.2+. 3.2 is the tightest floor that doesn't give up features we use.
+
+**Compatibility gotchas the CI matrix proves:**
+- Ruby 3.4's `ostruct` deprecation warnings hit Mongoid 9 internals. The Gemfile pins `ostruct` when `RUBY_VERSION >= '3.5'`; earlier 3.4 deprecation warnings are tolerated in the CLI integration spec.
+- Ruby 4.0's default-gem removal of `ostruct` is handled by the same `ostruct` pin.
+
+## MongoDB version support
+
+- **Minimum: MongoDB 5.0.** Required for time-series collections (the `samples` collection uses `timeField`/`metaField`/`granularity`/`expire_after` all of which are 5.0+ features).
+- **CI-tested: 6.0 and 7.0.** 6.0 is the earliest Mongo image available in GitHub Actions `services:`.
+- The floor claim for 5.0 is **asserted** but not tested in CI directly. A regression that broke 5.0 but not 6.0 wouldn't be caught automatically.
+
+Mongo driver (`mongo`, pulled in transitively by `mongoid`) is constrained by Mongoid 9 to `bson < 6`. When `bson 6` ships, cgminer_monitor can't upgrade until Mongoid 10 lands and we bump the constraint.
+
+## CI matrix (`.github/workflows/ci.yml`)
+
+Four jobs:
+
+### `lint`
+- Runs RuboCop on Ruby 3.4.
+- Separate job so rubocop failures don't block test results for other Ruby versions.
+
+### `test`
+- Matrix: Ruby 3.2/3.3/3.4 × Mongo 7, plus Ruby 3.4 × Mongo 6 (for Mongo version coverage), Ruby 4.0 × Mongo 7 (experimental), Ruby head × Mongo 7 (experimental).
+- Runs `bundle exec rspec --exclude-pattern 'spec/integration/**/*_spec.rb'`. Integration specs are slower, so they run on their own job below.
+- Mongo comes from `services: mongo: image: mongo:<v>`.
+
+### `integration`
+- Runs on Ruby 3.4 × Mongo 7 only. One matrix cell.
+- Runs `bundle exec rspec spec/integration/ -fd` (documentation formatter for readability).
+
+### `openapi-check`
+- Runs on Ruby 3.4 × Mongo 7.
+- Runs `bundle exec rspec spec/openapi_consistency_spec.rb -fd`.
+- Separate job so openapi drift is a distinct red signal from test failures.
+
+All jobs use `ruby/setup-ruby@v1` with `bundler-cache: true` for gem caching between runs.
+
+Triggers: `push` and `pull_request` on `master` or `develop`.
+
+## External dependencies (not Ruby gems)
+
+- **cgminer itself** — the gem queries cgminer's JSON API. The fixture file at `spec/support/cgminer_fixtures.rb` (shared with `cgminer_api_client`) is grounded in cgminer 4.11.1's `codes[]` table from `cgminer/api.c`. The wire format has been stable for years.
+- **MongoDB** — runtime only. See above for version support.
+- **Docker** (optional but recommended for dev) — a `Dockerfile` and `docker-compose.yml` are provided.
+
+## Dependency update strategy
+
+No Dependabot or Renovate configured. Manual bumps when breakage is reported or when picking up wanted features. Minimum version constraints are intentionally permissive-above-a-floor (`rspec >= 3.13`, `puma >= 6.0`, etc.) so `bundle install` resolves current versions without over-constraining downstream lockfiles.
+
+Consumers: `Gemfile.lock` is **not** committed (per gem convention). Operators installing the gem generate their own.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,72 @@
+# Knowledge Base Index — `cgminer_monitor`
+
+**This file is the entry point for AI assistants working on `cgminer_monitor`.** It summarizes every other document in `docs/` so an assistant can pull in only the file(s) relevant to a given question. When no single file is an obvious fit, read `AGENTS.md` (consolidated, at repo root) or skim `codebase_info.md` first.
+
+## How to use this index
+
+1. **Identify the question category** from the table below (Architecture? HTTP API? Data model? Operational concern?).
+2. **Read the mapped file.** Each mapping includes a one-line "use this when" hook plus a brief summary below.
+3. **Cross-reference** via the explicit links between documents — they're maintained.
+4. **Fall back** to reading the code. All docs are derived from `lib/`, `bin/`, and `spec/`; if a doc and the code disagree, the code is truth and the doc is stale (please flag it).
+
+## Question → file map
+
+| If the question is about... | Start here |
+|---|---|
+| "what is this project?" / stack / file tree / module graph | [`codebase_info.md`](codebase_info.md) |
+| two-thread execution model / signal-handler dance / graceful shutdown / why things are shaped this way | [`architecture.md`](architecture.md) |
+| what each class/module does / responsibilities / where to find X | [`components.md`](components.md) |
+| HTTP API contracts / CLI exit codes / env-var table / `miners.yml` schema / structured-log schema | [`interfaces.md`](interfaces.md) |
+| MongoDB collection shapes / `Sample`/`Snapshot` fields / `Config` invariants / error hierarchy | [`data_models.md`](data_models.md) |
+| startup / polling loop / HTTP request lifecycle / test harness / release process | [`workflows.md`](workflows.md) |
+| runtime + dev deps / Ruby + Mongo version floors / CI matrix | [`dependencies.md`](dependencies.md) |
+| known gaps, inconsistencies, caveats in the docs themselves / cleanup recommendations | [`review_notes.md`](review_notes.md) |
+
+## Document summaries
+
+### [`codebase_info.md`](codebase_info.md)
+**Purpose:** The one-pager. What cgminer_monitor is (a standalone daemon, not a Rails engine anymore as of 1.0), what Ruby/Mongo versions it supports, the full file tree, and a high-level module graph. **Start here if you've never seen the project.**
+
+### [`architecture.md`](architecture.md)
+**Purpose:** Why the code is shaped the way it is. Covers: the two-thread model (Poller + Puma), the signal-handler reinstall dance around Puma's `setup_signals`, graceful shutdown via a `Queue` + `ConditionVariable`, the read-path vs write-path decoupling via Mongo, `Config`-as-Data.define immutability, OpenAPI as source of truth. **Read this before making non-trivial structural changes.**
+
+### [`components.md`](components.md)
+**Purpose:** Catalog of every file in `lib/` (and the two test-only helpers). Each entry lists responsibilities, key public methods, and what calls into it. Includes the CLI subcommand table with exit codes. **Read this to find where a specific piece of behavior lives.**
+
+### [`interfaces.md`](interfaces.md)
+**Purpose:** Exhaustive contract reference. CLI (subcommands, exit codes, stdout/stderr contract). Env-var config table. `miners.yml` schema. Full HTTP API contract (every endpoint, every query parameter, every response shape, every error code). Structured-log event schema. Upstream dependencies (`cgminer_api_client`, MongoDB). **Read this for API/CLI/config questions.**
+
+### [`data_models.md`](data_models.md)
+**Purpose:** Runtime data. MongoDB collection shapes for `samples` (time-series) and `latest_snapshot` (regular) — fields, indexes, TTL. `Config` value object invariants. `Sample`/`Snapshot` Mongoid model specifics (why `store_in` is programmatic for `Sample`). Error class hierarchy. Raw vs. stored cgminer response shape. **Read this for "what's in the database" or "what fields does X have."**
+
+### [`workflows.md`](workflows.md)
+**Purpose:** Sequence diagrams and step-by-step flows. Startup, polling, request handling, graceful shutdown. Dev test workflow (unit, integration, openapi-check). Docker Compose dev stack. Release process. **Read this to understand how code paths compose over time.**
+
+### [`dependencies.md`](dependencies.md)
+**Purpose:** Runtime deps (cgminer_api_client, mongoid, sinatra, puma, rack-cors) and dev deps. Ruby/Mongo version rationale. CI matrix (lint/test/integration/openapi-check jobs). Mongoid 9 ↔ BSON 6 constraint. **Read this for "can I add gem X?", "what Rubies does this support?", or "why is Mongoid pinned."**
+
+### [`review_notes.md`](review_notes.md)
+**Purpose:** Self-audit. Consistency checks across other docs. Known gaps where the code is fuzzy (e.g., `DEBUG` env var documented but unwired, `StorageError`/`PollError` declared but unused, class-attr shadowing on Server/HttpApp). Cleanup recommendations with effort/value triage. **Read this before trusting a confident-sounding claim elsewhere in these docs.**
+
+## Example queries and where to go
+
+| Query | Primary file(s) |
+|---|---|
+| "How do I add a new HTTP endpoint?" | `components.md` (HttpApp) + `architecture.md` (OpenAPI enforcement) + `workflows.md` (openapi consistency check) + the root `AGENTS.md` for the exact step list |
+| "How do I add a new extracted metric?" | `components.md` (`Poller#extract_samples`) + `data_models.md` (sample meta shape) |
+| "What happens if Mongo goes away mid-poll?" | `architecture.md` (Poller error handling) + `workflows.md` (polling flow) + `interfaces.md` (Logger event names) |
+| "What's the CLI exit code when…?" | `interfaces.md` (CLI table) + `components.md` (bin/cgminer_monitor) |
+| "Why is `Server.started_at` read from `HttpApp.started_at`?" | `architecture.md` (class-level state pattern) + `review_notes.md` (gap #3) |
+| "Can I run this with MongoDB 4.4?" | `dependencies.md` (Mongo version support) — no, time-series requires 5.0+ |
+| "What's the schema of the `/v2/graph_data/hashrate` response?" | `interfaces.md` (HTTP API → Graph data) |
+| "Where does cgminer's `\"Pool Rejected%\"` end up in Mongo?" | `data_models.md` (Sample meta shape) — `metric: "pool_rejected_pct"` |
+
+## Maintenance note
+
+These docs were generated by analyzing the 1.0.0 source. They reflect the state at that release. When the code changes substantially:
+
+- Prefer updating the specific file that contains the affected claim (smaller diffs, clearer history).
+- Update `review_notes.md` if you find a new inconsistency or gap.
+- Re-run the codebase-summary skill in `update_mode=true` if the surface area has shifted enough to warrant a re-analysis.
+
+If you're an AI assistant and you find a doc that contradicts the current code, **trust the code** and flag the discrepancy to the maintainer rather than silently fixing the doc.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1,0 +1,294 @@
+# Interfaces
+
+`cgminer_monitor` has four distinct surfaces:
+1. The **CLI** (`cgminer_monitor` binary).
+2. The **environment-variable config**.
+3. The **`miners.yml`** file.
+4. The **HTTP API** (including Prometheus and OpenAPI/Swagger endpoints).
+
+And it consumes two external interfaces:
+5. **`cgminer_api_client`** (Ruby library) — for talking to cgminer.
+6. **MongoDB** — for persistence.
+
+## 1. CLI
+
+### Binary
+
+```
+cgminer_monitor <command> [options]
+```
+
+### Subcommands
+
+| Command | Purpose | Exit codes |
+|---|---|---|
+| `run` | Start the service in the foreground. Blocks until SIGTERM/SIGINT. | `0` clean shutdown, `1` crash, `78` config error |
+| `migrate` | Create MongoDB collections and indexes. Idempotent — safe to run on every deploy. | `0` ok, `1` Mongo error, `78` config error |
+| `doctor` | Print config (with mongo URL redacted), test Mongo connectivity, ping every configured miner. Read-only. | always `0` |
+| `version` / `-v` / `--version` | Print `cgminer_monitor <VERSION>` | `0` |
+| `start` / `restart` / `status` / `stop` | Deprecated shims from the 0.x Daemon-based CLI. Print a "did you mean…" hint. | `64` |
+| unknown or missing | Print a usage block. | `64` (`EX_USAGE`) |
+
+Exit code semantics follow [`sysexits(3)`](https://man.openbsd.org/sysexits.3):
+- `0` — success.
+- `1` — unspecified failure (server crash, unexpected exception).
+- `64` (`EX_USAGE`) — invocation error.
+- `78` (`EX_CONFIG`) — configuration validation failed.
+
+### Output streams
+
+**stdout:**
+- `run`: structured log lines (one per event). Format controlled by `CGMINER_MONITOR_LOG_FORMAT` (`json` or `text`).
+- `migrate`: log line for `migrate.complete`, then `migrate: done`.
+- `doctor`: human-readable diagnostics (headers, indented key/value pairs, `OK` / `FAILED` per check).
+- `version`: single line.
+
+**stderr:**
+- Usage hints and deprecated-subcommand warnings.
+- Unexpected configuration errors from `run`/`migrate`: `Configuration error: <message>`.
+- Unexpected Mongo errors from `migrate`: `MongoDB error during migration: <ClassName>: <message>`.
+
+Library-level code never writes directly to stderr — everything flows through `CgminerMonitor::Logger`, which writes to stdout. The only direct `warn` calls are in `bin/cgminer_monitor` itself, gated on the top-level error type.
+
+### Environment variables consumed by the CLI
+
+`DEBUG` — currently documented in the README env table as "set to `1` for full backtraces on crashes." In 1.0.0 the CLI doesn't actually branch on `DEBUG`; the Server logs `backtrace:` automatically on `server.crash`. Treat this as a planned knob rather than wired-up behavior. (Flagged in `review_notes.md`.)
+
+## 2. Environment-variable config
+
+All knobs are `ENV` reads at boot via `Config.from_env`. Defaults in parentheses.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `CGMINER_MONITOR_INTERVAL` | `60` | Seconds between poll cycles. Must be > 0. |
+| `CGMINER_MONITOR_RETENTION_SECONDS` | `2592000` (30 days) | Time-series data TTL. Applied via Mongo's `expire_after` at `create_collection` time. |
+| `CGMINER_MONITOR_MONGO_URL` | `mongodb://localhost:27017/cgminer_monitor` | Mongoid client URI. Secrets in this string are redacted in logs. |
+| `CGMINER_MONITOR_HTTP_HOST` | `127.0.0.1` | Puma bind address. Set to `0.0.0.0` inside Docker. |
+| `CGMINER_MONITOR_HTTP_PORT` | `9292` | Puma bind port. |
+| `CGMINER_MONITOR_HTTP_MIN_THREADS` | `1` | Puma min threads. |
+| `CGMINER_MONITOR_HTTP_MAX_THREADS` | `5` | Puma max threads. |
+| `CGMINER_MONITOR_MINERS_FILE` | `config/miners.yml` | Path to miners YAML. |
+| `CGMINER_MONITOR_LOG_FORMAT` | `json` | `json` or `text`. |
+| `CGMINER_MONITOR_LOG_LEVEL` | `info` | `debug`, `info`, `warn`, or `error`. |
+| `CGMINER_MONITOR_CORS_ORIGINS` | `*` | Comma-separated list for `Rack::Cors`, or `*` for permissive. |
+| `CGMINER_MONITOR_SHUTDOWN_TIMEOUT` | `10` | Seconds to wait for each of Poller and Puma to stop during graceful shutdown. |
+| `CGMINER_MONITOR_HEALTHZ_STALE_MULTIPLIER` | `2` | Stale threshold = `interval * multiplier` seconds since last poll before `/healthz` returns `degraded`. |
+| `CGMINER_MONITOR_HEALTHZ_STARTUP_GRACE` | `60` | Seconds after boot during which a missing poll still reports `starting` rather than `degraded`. |
+| `DEBUG` | unset | Documented-but-not-yet-used toggle for backtrace printing (see above). |
+
+`Config#validate!` fails hard on: non-positive `interval`, unknown `log_format`, nonexistent `miners_file`, unknown `log_level`. Integer parse errors surface the offending env var name verbatim.
+
+## 3. `miners.yml`
+
+YAML array of miner descriptors. Loaded at boot by `Server#validate_startup!` and by `Poller#build_miner_pool`.
+
+```yaml
+- host: 192.168.1.10
+  port: 4028
+  timeout: 5
+- host: 192.168.1.11
+  port: 4028
+- host: miner3.local
+```
+
+| Key | Required | Type | Default |
+|---|---|---|---|
+| `host` | yes | string (IP or hostname) | — |
+| `port` | no | integer | `4028` (cgminer default) |
+| `timeout` | no | integer (seconds) | whatever `cgminer_api_client` defaults to (currently 5s) |
+
+Parsed with `YAML.safe_load_file`. An empty array or missing file fails `validate_startup!` as a `ConfigError`.
+
+## 4. HTTP API
+
+Base URL: `http://<host>:<port>/` where host/port come from `CGMINER_MONITOR_HTTP_HOST` / `CGMINER_MONITOR_HTTP_PORT` (defaults `127.0.0.1:9292`).
+
+### Health
+
+```
+GET /v2/healthz
+```
+
+Returns a snapshot of liveness/readiness.
+
+HTTP status:
+- `200` if `status ∈ {healthy, starting}`
+- `503` if `status == "degraded"`
+
+Response body:
+```json
+{
+  "status": "healthy",
+  "mongo": true,
+  "last_poll_at": "2026-04-19T13:45:12Z",
+  "last_poll_age_s": 17,
+  "miners_configured": 3,
+  "miners_available": 3,
+  "uptime_s": 1234
+}
+```
+
+State transitions:
+- `starting` — Mongo is up, no poll has happened yet, and uptime < `CGMINER_MONITOR_HEALTHZ_STARTUP_GRACE`.
+- `healthy` — Mongo is up and the most recent poll is newer than `interval * healthz_stale_multiplier` seconds.
+- `degraded` — anything else (Mongo unreachable, polls stale, or the startup grace window has elapsed without a poll).
+
+### Prometheus metrics
+
+```
+GET /v2/metrics
+```
+
+`Content-Type: text/plain; version=0.0.4; charset=utf-8`. Exposes:
+- `cgminer_hashrate_ghs{miner, window}` — gauge. `window="5s"` and `"avg"`, from `latest_snapshot.summary.SUMMARY[0]`.
+- `cgminer_temperature_celsius{miner, device}` — gauge. Per-device from `latest_snapshot.devs.DEVS`.
+- `cgminer_available{miner}` — gauge. `1` if the most recent snapshot (any command) was ok; `0` otherwise.
+- `cgminer_monitor_polls_total{result="ok"|"failed"}` — counter. Read from the live `Poller` instance.
+- `cgminer_monitor_last_poll_age_seconds` — gauge. `-1` if no poll has happened yet.
+
+### Miners list
+
+```
+GET /v2/miners
+```
+
+```json
+{
+  "miners": [
+    {
+      "id": "192.168.1.10:4028",
+      "host": "192.168.1.10",
+      "port": 4028,
+      "available": true,
+      "last_poll": "2026-04-19T13:45:12Z"
+    }
+  ]
+}
+```
+
+The miners list is derived from `HttpApp.configured_miners_cache` (built once from `miners.yml`); `available` and `last_poll` come from `latest_snapshot`.
+
+### Per-miner snapshots
+
+```
+GET /v2/miners/:miner/summary
+GET /v2/miners/:miner/devices
+GET /v2/miners/:miner/pools
+GET /v2/miners/:miner/stats
+```
+
+`:miner` is `host:port` URL-encoded (colon → `%3A`). Unknown miner IDs return `404 {"error": "unknown miner: <id>", "code": "not_found"}`.
+
+Response body:
+```json
+{
+  "miner": "192.168.1.10:4028",
+  "command": "summary",
+  "fetched_at": "2026-04-19T13:45:12Z",
+  "ok": true,
+  "response": { "STATUS": [...], "SUMMARY": [...] },
+  "error": null
+}
+```
+
+If no snapshot exists yet, `fetched_at`, `ok`, `response`, and `error` are all `null`.
+
+### Graph data (time-series)
+
+```
+GET /v2/graph_data/hashrate
+GET /v2/graph_data/temperature
+GET /v2/graph_data/availability
+```
+
+Query parameters (all optional):
+- `miner` — filter to one miner (`host:port`). Omit for pool-wide aggregates.
+- `since`, `until` — time range. ISO-8601 (`2026-04-19T12:00:00Z`) or relative (`1h`, `30m`, `7d`, `2w`). Defaults to the last hour.
+
+Response body shape:
+```json
+{
+  "miner": "192.168.1.10:4028",
+  "metric": "hashrate",
+  "since": "2026-04-19T12:45:12Z",
+  "until": "2026-04-19T13:45:12Z",
+  "fields": ["ts", "ghs_5s", "ghs_av", "device_hardware_pct", "device_rejected_pct", "pool_rejected_pct", "pool_stale_pct"],
+  "data": [[1713534312, 14000000.0, 14010000.0, 0.0, 0.99, 0.99, 0.0], ...]
+}
+```
+
+`fields` differs per metric:
+- **hashrate:** 7 fields as shown above.
+- **temperature:** `["ts", "min", "avg", "max"]`.
+- **availability (per-miner):** `["ts", "available"]` — `available ∈ {0, 1}`.
+- **availability (pool-wide):** `["ts", "available", "configured"]`.
+
+Responses carry `Cache-Control: public, max-age=<interval>` so intermediate caches don't hammer Mongo for the same bucket.
+
+Invalid `since`/`until` values return `400 {"error": "invalid time parameter: <value>", "code": "invalid_request"}`.
+
+### OpenAPI and Swagger UI
+
+```
+GET /openapi.yml   → OpenAPI 3.1 spec as text/yaml
+GET /docs          → Swagger UI HTML (hits /openapi.yml for the spec)
+```
+
+The spec file is packaged with the gem at `lib/cgminer_monitor/openapi.yml` and is CI-guarded for route parity by `spec/openapi_consistency_spec.rb`.
+
+### Error shape
+
+All 4xx/5xx responses use `application/json`:
+```json
+{ "error": "<human-readable message>", "code": "<machine code>" }
+```
+
+Codes: `not_found`, `invalid_request`, `internal`. Unhandled exceptions log `http.unhandled_error` via `Logger.error` and return `500 {"error": "internal", "code": "internal"}` without leaking the exception class or backtrace.
+
+### What the HTTP API does NOT do
+
+- No authentication, no authorization. Anyone who can reach the port can read everything.
+- No writes. Nothing mutates state via HTTP; everything in the database was written by the Poller.
+- No WebSockets, no streaming, no long-polling. Clients poll the endpoints.
+- No support for `HEAD`, `POST`, `PUT`, `DELETE`, or `PATCH`. `OPTIONS` is handled by CORS middleware.
+
+## 5. Upstream: `cgminer_api_client`
+
+Hard runtime dependency (`~> 0.3.0`). Used by `Poller` to talk to cgminer:
+
+- `CgminerApiClient::MinerPool` — parallel fan-out across every configured miner.
+- `CgminerApiClient::Miner` — used transiently in `cgminer_monitor doctor` for per-miner `version` pings.
+- `CgminerApiClient::MinerResult` — per-miner outcomes inside a `PoolResult`.
+- Errors: `CgminerApiClient::ConnectionError`, `CgminerApiClient::ApiError` — caught at the Poller boundary and translated into failed `Snapshot` rows (`ok: false, error: "<ClassName>: <message>"`).
+
+The Poller deliberately does not use `CgminerApiClient::MinerPool.new` (which hard-codes `'config/miners.yml'` relative to CWD). Instead it uses `MinerPool.allocate` + manually sets `.miners=`. See `architecture.md` for why.
+
+## 6. Upstream: MongoDB
+
+Minimum version **5.0** (for time-series collections). CI tests against 6.0 and 7.0; 5.0 isn't available in GitHub Actions service containers but the feature set used has been stable since 5.0.
+
+Connection: single-URI via Mongoid, configured programmatically from `CGMINER_MONITOR_MONGO_URL`. No `mongoid.yml`.
+
+Collections:
+- **`samples`** (time-series): `timeField: ts`, `metaField: meta`, `granularity: minutes`, `expire_after: <retention>`. Created by `cgminer_monitor migrate` or `Server#bootstrap_mongoid!`.
+- **`latest_snapshot`** (regular): compound unique index on `(miner, command)`, plus an index on `fetched_at`.
+
+Writes use `Sample.collection.insert_many(...)` and `Snapshot.collection.bulk_write(ops, ordered: false)` for throughput. Reads go through `Sample.where(...)` / `Snapshot.where(...)` via Mongoid's `Criteria`, with one raw aggregation pipeline in `SnapshotQuery.miners` for the collapse-per-miner projection.
+
+## Structured log schema
+
+Every log line is a JSON object (default) or a tokenized text line. Guaranteed fields: `ts`, `level`, `event`. Event-specific fields follow.
+
+Notable events (non-exhaustive):
+- `server.start`, `server.stopping`, `server.stopped`, `server.crash`
+- `puma.crash`
+- `poll.complete` with `samples_written`, `snapshots_upserted`, `polls_ok`, `polls_failed`
+- `poll.miner_failed` with `miner`, `command`, `error`
+- `poll.unexpected_error` with `error`, `message`, `backtrace`
+- `mongo.write_failed` with `error`, `message`
+- `startup.mongo_unreachable`
+- `healthz.mongo_unreachable`
+- `migrate.complete`
+- `http.unhandled_error` with `error`, `message`, `backtrace`
+
+Log levels: `debug` / `info` / `warn` / `error`. `info` is the default floor.

--- a/docs/review_notes.md
+++ b/docs/review_notes.md
@@ -1,0 +1,82 @@
+# Review Notes
+
+Self-audit of the documentation set. Honest list of what I couldn't fully verify, known gaps, and the items I'd flag for cleanup work. Read this before trusting a confident-sounding claim elsewhere in `docs/`.
+
+## Consistency check
+
+I cross-referenced the following claims across files and found no contradictions:
+
+| Claim | Asserted in | Verified |
+|---|---|---|
+| Two-thread model (Poller + Puma) | `codebase_info.md`, `architecture.md`, `components.md`, `workflows.md` | consistent |
+| `Config` is an immutable `Data.define` | `codebase_info.md`, `architecture.md`, `components.md`, `data_models.md` | consistent |
+| Mongoid is configured programmatically from `CGMINER_MONITOR_MONGO_URL` (no `mongoid.yml`) | `codebase_info.md`, `architecture.md`, `interfaces.md`, `dependencies.md` | consistent |
+| CLI exit codes 0/1/64/78 | `interfaces.md`, `components.md`, `workflows.md` | consistent |
+| `samples` is time-series, `latest_snapshot` is regular | `architecture.md`, `data_models.md`, `components.md`, `dependencies.md` | consistent |
+| Ruby 3.2+ / Mongo 5.0+ floors | `codebase_info.md`, `dependencies.md` | consistent |
+| Signal-handler reinstall dance after Puma start | `architecture.md`, `components.md`, `workflows.md` | consistent |
+| HttpApp has class-level state (poller, started_at, configured_miners_cache) | `architecture.md`, `components.md`, `interfaces.md` | consistent |
+
+Nothing contradictory. If later edits introduce drift, re-run this section.
+
+## Completeness gaps
+
+Areas where the code hasn't fully settled a question, or where the docs are correctly describing a known fuzzy area:
+
+### 1. `DEBUG` env var is documented but not wired
+The README's env-var table says `DEBUG=1` gives full backtraces on crashes. In the 1.0.0 code, neither `Config` nor `bin/cgminer_monitor` branches on `DEBUG`. The `Server` already logs full backtraces on `server.crash`, so the behavior happens to match the documented promise — but the control knob doesn't exist. Either wire it up (make backtrace logging conditional) or remove the row from the README.
+
+### 2. `StorageError` and `PollError` are declared but unused
+Both classes are defined in `lib/cgminer_monitor/errors.rb` but nothing in `lib/` raises them. `Mongo::Error` is caught at the Poller boundary and logged directly; cgminer errors are captured inside `MinerResult.failure` objects. Either wire these in (rewrap external errors as gem-specific ones), or delete them. Currently they're shelfware.
+
+### 3. `Server.started_at` and `Server.poller` shadow `HttpApp.*`
+`Server#run` sets class-level attrs on both `Server` itself and `HttpApp` — same values. `HttpApp` is the reader; `Server`'s copy is never consulted. Low-priority cleanup: remove `Server.started_at` and `Server.poller`, update tests.
+
+### 4. Mongo 5.0 floor is asserted but not tested in CI
+The CI matrix uses Mongo 6 and 7 because 5.0 isn't available as a GitHub Actions service container. A regression that broke 5.0 while remaining compatible with 6.0 wouldn't be caught. If 5.0 support is load-bearing for any user, add a spec that uses a locally-pulled Mongo 5 image (outside GitHub Actions services).
+
+### 5. `DEBUG` + backtraces + JSON log format
+Even today, `Logger.error` with `backtrace: e.backtrace&.first(10)` produces a `backtrace` JSON array inside the log entry. In `text` format, that shows up as `backtrace=["...", "..."]` (Ruby array stringification). Not ideal for human reading. The "JSON vs text" format choice doesn't really matter at error-time because the backtrace field is always present.
+
+### 6. Thread safety of `Config.current` memoization
+`Config.current ||= from_env` is a classic lazy init that isn't thread-safe if called concurrently by multiple threads on the first call. In practice, `Server` always hits `Config.current` through the main thread before the Poller or Puma threads start, so this is not currently exploitable. But there's no lock; if a future refactor has the Poller initialize before `HttpApp.configured_miners_cache` is first touched, the race could surface. Consider a `Mutex` around the memoization or early-init in `Server#run`.
+
+### 7. No shutdown path for migrate/doctor subcommands
+`cgminer_monitor migrate` and `doctor` install Mongoid clients and exit. Mongoid's driver keeps background connection monitors running in threads, which can delay Ruby process exit briefly. Not broken — just sometimes a surprising few-second pause before shell prompt returns. No action needed unless it bites someone.
+
+### 8. `HttpApp#configured_miners_cache` is loaded from disk at first request
+The cache is lazily built on the first call into `configured_miners`. If the first request comes before the Poller does its first poll, and if `miners.yml` is unreadable by the process (rare), the request would raise. Not observed; flagged as a pedantic correctness note.
+
+### 9. `extract_samples` doesn't document its numeric coercion
+`to_numeric(value)` coerces `Integer`/`Float` as-is and tries `Float(value, exception: false)` on strings. Booleans, nil, and other types are silently skipped. This is intentional (we don't want to record `"Y"` or `"Alive"` as samples) but the code has no comment explaining the policy; the `review_notes.md` is the first place it's written down.
+
+### 10. No integration test for `run` with real signal delivery
+`spec/integration/cli_spec.rb` tests `migrate`, `doctor`, `version`, and the deprecated shims by spawning subprocesses. But it doesn't test `run` end-to-end (start, poll, SIGTERM, clean shutdown). Orchestrating signal delivery from a spec process is fiddly but doable; until then, the shutdown path is only exercised by the unit specs for `Server`, which mock the Puma launcher.
+
+## Language and tooling limitations
+
+- **Ruby-only** — no FFI, no native extensions.
+- **macOS and Linux only in practice.** Windows isn't explicitly unsupported but isn't tested.
+- **CI only on ubuntu-24.04.**
+- **Integration tests require MongoDB running.** There's no embedded-Mongo fallback.
+
+## Recommendations
+
+Low effort, high value:
+1. Wire up `DEBUG=1` in `bin/cgminer_monitor` to gate backtrace logging (or remove it from the README env table).
+2. Delete `StorageError` and `PollError` (unless there's a plan to raise them).
+3. Remove `Server.started_at` and `Server.poller` class attrs; keep only the `HttpApp` ones.
+
+Medium effort, possibly worth it:
+4. Add a spec that exercises `Server#run` end-to-end with real signal delivery.
+5. Replace `HttpApp.configured_miners_cache` with an instance variable set explicitly by `Server#run`; keeps the state flow in one place and removes one of the reset-for-tests pitfalls.
+
+Higher effort, defer:
+6. Add a Mongo 5.0 CI lane (outside GitHub Actions services) so the 5.0 floor claim is actually enforced.
+7. Revisit the `Config.current` memoization thread-safety if the process model ever changes.
+
+## How I validated
+
+- Read every file under `lib/`, `bin/`, `spec/support/`, the CI workflow, `Rakefile`, `.rubocop.yml`, `.rspec`, `Gemfile`, the gemspec, the Dockerfile and compose file, `config/miners.yml.example`, README, CHANGELOG, MIGRATION.
+- Did not run the test suite as part of writing these docs. "Tested" claims are derived from reading the specs and the CI workflow, not from a pass/fail run.
+- Did not verify the OpenAPI spec's contents against each route response shape — only the existence-and-presence guard that `spec/openapi_consistency_spec.rb` enforces.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,273 @@
+# Workflows
+
+Four runtime flows cover essentially everything: startup, polling, HTTP request handling, and graceful shutdown. Plus three dev/test workflows: running the suite locally against a fake cgminer + real Mongo, the OpenAPI consistency check, and the Docker Compose dev stack.
+
+## 1. Startup (`cgminer_monitor run`)
+
+```mermaid
+sequenceDiagram
+    participant CLI as bin/cgminer_monitor
+    participant Config
+    participant Logger
+    participant Server
+    participant Mongoid
+    participant Mongo
+    participant Sample
+    participant Snapshot
+    participant Poller
+    participant Puma
+    participant HttpApp
+
+    CLI->>Config: Config.from_env (parses ENV, validates)
+    alt invalid env
+        Config--xCLI: raise ConfigError
+        CLI--xCLI: warn, exit 78
+    end
+    CLI->>Logger: format= / level= from config
+    CLI->>Server: Server.new(config) and .run
+
+    Server->>Server: install_signal_handlers (trap TERM/INT → @stop)
+    Server->>Mongoid: configure clients.default = {uri: mongo_url}
+    Server->>Mongo: database_names (reachability check)
+    alt mongo unreachable
+        Mongo--xServer: Mongo::Error
+        Server--xCLI: raise, log 'startup.mongo_unreachable', exit 1
+    end
+    Server->>Server: YAML.safe_load_file miners_file
+    alt miners.yml empty or missing
+        Server--xCLI: raise ConfigError, exit 78
+    end
+
+    Server->>Sample: store_in(collection_options: time_series + expire_after)
+    Server->>Sample: create_collection
+    Server->>Snapshot: create_indexes
+
+    Server->>HttpApp: HttpApp.poller = poller / .started_at = now
+    Server->>Logger: Logger.info 'server.start'
+
+    Server->>Poller: Thread.new { poller.run_until_stopped }
+    Server->>Puma: build launcher (threads, bind, raise_exception_on_sigterm=false)
+    Server->>Puma: Thread.new { launcher.run }
+    Server->>Server: reinstall_signal_handlers (after 50ms)
+
+    Server->>Server: @stop.pop (block until signal)
+```
+
+**Key observations:**
+- `Config.from_env` is the single place env vars turn into a validated snapshot. Every subsequent reader sees the same immutable record.
+- Two things can make startup fail: a `ConfigError` (exit 78) or anything else — mongo unreachable, miners_file issues — that bubbles out (exit 1).
+- The signal-handler install → Puma start → reinstall sequence is load-bearing. See `architecture.md` for the gory details.
+- `HttpApp` gets wired up **before** the Poller thread starts, so the very first request to `/healthz` after boot returns a sane response even if no poll has happened yet (`status: starting` when `mongo: true`, `last_poll_at: null`, and `uptime_s < startup_grace`).
+
+## 2. Polling (`Poller#run_until_stopped`)
+
+```mermaid
+sequenceDiagram
+    participant Loop as run_until_stopped
+    participant Clock
+    participant Poller as poll_once
+    participant Pool as CgminerApiClient::MinerPool
+    participant Miners as miner threads
+    participant Cgminer
+    participant Sample
+    participant Snapshot
+    participant Mongo
+    participant Logger
+    participant Sleep as interruptible_sleep
+
+    loop until @stopped
+        Loop->>Clock: started_at = CLOCK_MONOTONIC
+        Loop->>Poller: poll_once
+
+        loop each of [summary, devs, pools, stats]
+            Poller->>Pool: pool.query(command)
+            par one thread per miner
+                Pool->>Miners: miner.query(command)
+                Miners->>Cgminer: TCP JSON request
+                Cgminer-->>Miners: response
+                Miners-->>Pool: MinerResult.success or failure
+            end
+            Pool-->>Poller: PoolResult
+        end
+
+        loop each miner
+            alt miner_result.ok? for this command
+                Poller->>Poller: extract_samples (numeric fields only)
+                Poller->>Poller: build snapshot upsert {ok: true, response:}
+            else
+                Poller->>Poller: build snapshot upsert {ok: false, error:}
+                Poller->>Logger: 'poll.miner_failed'
+            end
+            Poller->>Poller: append synthetic 'poll' samples (ok, duration_ms)
+        end
+
+        Poller->>Sample: collection.insert_many(all_samples)
+        Poller->>Snapshot: collection.bulk_write(ops, ordered: false)
+        Poller->>Logger: 'poll.complete' with counts
+
+        Loop->>Clock: elapsed = CLOCK_MONOTONIC - started_at
+        Loop->>Sleep: remaining = interval - elapsed
+        alt remaining > 0
+            Sleep->>Sleep: @cv.wait(@mutex, remaining) unless @stopped
+        end
+    end
+```
+
+**Key observations:**
+- `CLOCK_MONOTONIC` is used for the interval accounting so clock-skew / NTP steps don't make the loop run fast or stall.
+- One cgminer command at a time per pool query, but within that query every miner is hit in parallel (cgminer_api_client's `MinerPool` spawns a thread per miner).
+- Errors from cgminer (per-miner) land as `MinerResult.failure` inside the `PoolResult`. `Poller#process_failure` turns those into failed `Snapshot` docs rather than letting them halt the poll.
+- `Mongo::Error` and generic `StandardError` at the top of `poll_once` are caught, counted, and logged. They don't crash the thread. The supervisor sees a process that's still running but whose `/metrics` `cgminer_monitor_polls_total{result="failed"}` is climbing.
+- `@cv.wait(@mutex, remaining)` is how `Poller#stop` can wake the sleep early — it signals the same condvar. See `architecture.md`.
+
+## 3. HTTP request handling
+
+A sample read-path flow, graph data:
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Puma
+    participant HttpApp
+    participant SampleQ as SampleQuery
+    participant Sample
+    participant Mongo
+
+    Client->>Puma: GET /v2/graph_data/hashrate?since=30m
+    Puma->>HttpApp: dispatch to sinatra route
+    HttpApp->>HttpApp: parse_time_range (30m → Time.now - 1800s)
+    HttpApp->>SampleQ: hashrate(miner: nil, since:, until_:)
+    SampleQ->>Sample: Sample.where(ts: range, 'meta.command': 'summary', 'meta.sub': 0, 'meta.metric' ∈ HASHRATE_METRICS)
+    Sample->>Mongo: find (bucketed time-series scan)
+    Mongo-->>Sample: samples
+    SampleQ->>SampleQ: group_by ts, per-metric aggregate (sum or mean)
+    SampleQ-->>HttpApp: [[ts, ghs_5s, ghs_av, ...], ...]
+    HttpApp->>HttpApp: set cache_control :public, max_age: interval
+    HttpApp-->>Client: 200 JSON
+```
+
+The `/healthz` flow differs in that it reads from `SnapshotQuery` (current state), checks Mongo reachability inline, consults `HttpApp.started_at`, and computes the `starting/healthy/degraded` state from `Config` thresholds.
+
+`/metrics` is an exception to the "read via query modules" pattern — it queries `Snapshot` directly for Prometheus gauges and reads the live `Poller` counters from `HttpApp.poller` for poll-total counters. Sinatra's `content_type` is overridden to `text/plain; version=0.0.4; charset=utf-8` for Prometheus compatibility.
+
+## 4. Graceful shutdown
+
+Triggered by SIGTERM, SIGINT, or a Puma-thread crash pushing `'puma_crash'` to the stop queue.
+
+```mermaid
+flowchart TD
+    A[Signal or Puma crash] --> B[push to @stop Queue]
+    B --> C[Main thread unblocks from @stop.pop]
+    C --> D[Logger.info 'server.stopping']
+    D --> E[poller.stop — set @stopped, @cv.signal]
+    E --> F[poller_thread.join with shutdown_timeout]
+    F -->|clean| G[puma_launcher.stop]
+    F -.timeout.- G
+    G --> H[puma_thread.join with shutdown_timeout]
+    H --> I[Logger.info 'server.stopped']
+    I --> J[Server#run returns 0]
+    J --> K[CLI exit 0]
+
+    X[Unhandled StandardError in Server#run body] --> Y[Logger.error 'server.crash' with backtrace]
+    Y --> Z[return 1 from Server#run]
+    Z --> ZZ[CLI exit 1]
+```
+
+**Timeouts are per-thread.** If the poller thread is mid-`insert_many` and can't finish within `CGMINER_MONITOR_SHUTDOWN_TIMEOUT` (default 10s), `join` returns without it. Same for Puma. Worst case, the supervisor sends SIGKILL a bit later and Mongo's connection drops mid-operation; since writes are bulk insert/upsert, this is generally safe.
+
+**Puma thread crashes** (exceptions inside `launcher.run`) are caught by `Thread.new do ... rescue Exception`, logged as `puma.crash`, and pushed to `@stop` so the main thread goes through the normal shutdown path.
+
+## 5. Local dev: running tests
+
+```sh
+# 1. Start Mongo for tests (keep it running)
+docker run -d --name cgminer-mongo-test -p 27017:27017 mongo:7
+
+# 2. Install gems
+bundle install
+
+# 3. Run tests + rubocop
+bundle exec rake
+
+# Or piecemeal:
+bundle exec rspec                                     # all specs
+bundle exec rspec spec/cgminer_monitor                # unit only
+bundle exec rspec spec/integration                    # integration only (needs Mongo + FakeCgminer)
+bundle exec rspec spec/openapi_consistency_spec.rb    # route ↔ openapi.yml parity
+bundle exec rspec path/to/spec.rb:123                 # single example by line
+bundle exec rubocop                                   # lint only
+bundle exec rubocop -A                                # auto-correct
+```
+
+Coverage is enabled automatically (SimpleCov in `spec_helper.rb`). Reports land in `coverage/`, which is `.gitignore`d.
+
+## 6. Integration test: FakeCgminer + real Mongo
+
+`spec/integration/full_pipeline_spec.rb` exercises the full write path end-to-end:
+
+```mermaid
+sequenceDiagram
+    participant Spec
+    participant FakeCgminer
+    participant Config
+    participant Poller
+    participant Mongo
+
+    Spec->>FakeCgminer: FakeCgminer.with { |port| ... }
+    FakeCgminer->>FakeCgminer: TCPServer on 127.0.0.1:port, Thread.new accept_loop
+    Spec->>Spec: write temp miners.yml pointing at 127.0.0.1:port
+    Spec->>Config: Config.from_env with overrides
+    Spec->>Poller: Poller.new(config)
+    Spec->>Poller: poller.poll_once
+    Poller->>FakeCgminer: query each of [summary, devs, pools, stats]
+    FakeCgminer-->>Poller: canned responses
+    Poller->>Mongo: insert_many samples + bulk_write snapshots
+    Spec->>Mongo: assert on Sample.count, Snapshot.count, doc shapes
+    Note over Spec,FakeCgminer: block exit: server.close, thread.join
+```
+
+`spec/integration/cli_spec.rb` spawns the real `bin/cgminer_monitor` binary via `Open3.capture3` and asserts on exit codes and stream contents for `migrate`, `doctor`, `version`, and the deprecated shims. It does **not** currently run the full `run` command end-to-end — that would require orchestrating signal delivery from the spec process, which is fiddly.
+
+`spec/integration/healthz_spec.rb` verifies the `starting → healthy → degraded` state transitions of `/healthz` under controlled time / config conditions.
+
+## 7. OpenAPI consistency check
+
+`spec/openapi_consistency_spec.rb` walks `HttpApp`'s Sinatra routes (`HttpApp.routes`) and cross-checks against `lib/cgminer_monitor/openapi.yml`:
+
+- Every route registered on `HttpApp` should have a corresponding `paths:` entry in `openapi.yml`.
+- Every path in `openapi.yml` should correspond to a registered route.
+
+CI runs this as its own job (`openapi-check`). Drift fails the build. Adding or removing routes requires updating `openapi.yml` in the same commit.
+
+## 8. Docker Compose dev stack
+
+```sh
+# Just Mongo (for local spec runs)
+docker-compose up -d mongo
+
+# Full stack (app + mongo)
+cp config/miners.yml.example config/miners.yml
+docker-compose up
+
+# With a FakeCgminer for end-to-end demos without real hardware
+docker-compose --profile testing up
+```
+
+The `fake_cgminer` service is gated under the `testing` profile so it doesn't come up by default. It mounts `spec/support/` into a raw `ruby:3.4-slim` image (not the app Dockerfile, which excludes `spec/`) and runs `FakeCgminer.with(port: 4028) { |p| ...; sleep }` as a foreground process. Operators point their `miners.yml` at `fake_cgminer:4028` inside the Compose network for wire-level sandboxing.
+
+## 9. Release
+
+Not automated. On a clean `master`:
+
+```sh
+bundle exec rake                                 # must pass
+# bump VERSION in lib/cgminer_monitor/version.rb
+# update CHANGELOG.md
+git commit -am "Release vX.Y.Z"
+gem build cgminer_monitor.gemspec                # produces cgminer_monitor-X.Y.Z.gem
+gem push cgminer_monitor-X.Y.Z.gem               # requires 2FA (rubygems_mfa_required)
+git tag vX.Y.Z
+git push origin master vX.Y.Z
+```
+
+Container images (Docker Hub / GHCR) aren't currently pushed by CI; if that happens later, it'd be a separate workflow triggered on tag push.


### PR DESCRIPTION
## Overview

Adds an AI-assistant knowledge base under `docs/` with a consolidated `AGENTS.md` at the repo root, and refreshes the README with exit-code, logging, and further-reading details that were previously only reachable by grepping through the code.

## Questions/Comments

The motivation for the `docs/` + `AGENTS.md` work is the same context rot that hit the sibling `cgminer_api_client` repo: every new assistant session — and every new human contributor — re-learns the same handful of things from the source (why signal handlers are reinstalled after Puma's `setup_signals`, why `Sample#store_in` is called programmatically instead of as a class macro, why `Poller#build_miner_pool` uses `MinerPool.allocate` + manual `.miners=` instead of the constructor, the `HttpApp` class-level state that tests have to reset). Pinning those down as versioned docs turns rediscovery into a lookup. There's also a `docs/review_notes.md` that deliberately records what I'm *not* sure about and flags small cleanup candidates (a `DEBUG` env var documented but unwired, `StorageError`/`PollError` declared but unraised, `Server.started_at`/`Server.poller` class attrs shadowing the `HttpApp` ones) so the docs stay honest.

The README refresh solves the same problem for operators rather than agents: someone running this under systemd shouldn't have to read `bin/cgminer_monitor` to learn that exit 78 means `EX_CONFIG`, and someone wiring up log aggregation shouldn't have to read `logger.rb` to see what events the service emits. The new Exit Codes and Logging subsections live under the existing CLI section without disturbing the env-var table, and a Further Reading section at the bottom points at CHANGELOG, MIGRATION, AGENTS.md, and docs/.

Because `docs/*` is in my global gitignore, the `.gitignore` picks up a `!docs/*.md` override — the markdown tracks, but anything else that lands in `docs/` (coverage HTML, scratch) still stays out.

Pure docs — no code changes, nothing for CI to re-verify beyond the usual `bundle exec rake`.