### PR TITLE
Move HttpApp class-level state to Sinatra settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ bin/cgminer_monitor run
 **Key structural facts:**
 
 1. **Two threads, one process, one `@stop` Queue.** Poller runs a `while !stopped` loop; Puma runs until `launcher.stop`. Main thread blocks on `@stop.pop` until a signal handler (or a Puma crash) pushes something.
-2. **`HttpApp` has class-level state** set by `Server` at boot: `.poller`, `.started_at`, `.configured_miners_cache`. Tests must call `HttpApp.reset_configured_miners!` between examples.
+2. **`HttpApp` state lives in Sinatra settings** set by `Server#run` at boot: `settings.poller`, `settings.started_at`, `settings.configured_miners`. Routes read `settings.foo`; tests use `HttpApp.configure_for_test!(miners:, poller:, started_at:)` to populate them.
 3. **`Config` is immutable.** `Data.define`. Validated once in `Config.from_env`. There's no hot reload. Config changes require a restart.
 4. **Mongoid is configured programmatically** from `CGMINER_MONITOR_MONGO_URL`. No `config/mongoid.yml` exists. This was explicit in the 1.0 rewrite.
 5. **`Sample.store_in` is called at runtime**, not as a class macro, because the `expire_after` depends on `Config#retention_seconds`. `Sample.create_collection` is called explicitly so the collection is actually time-series (not a regular lazy-created one).
@@ -146,7 +146,7 @@ bin/cgminer_monitor run
 - **`config.order = :random`** — specs must be order-independent.
 - **`mocks.verify_partial_doubles = true`** — doubles must match real method signatures.
 - Warnings are on in `.rspec`. Keep the suite warning-clean.
-- Between specs that touch `HttpApp.configured_miners_cache`, call `HttpApp.reset_configured_miners!`.
+- Specs that render routes call `HttpApp.configure_for_test!(miners:, poller:, started_at:)` in a `before` block to populate Sinatra settings.
 
 ## Running tests and lint
 
@@ -240,7 +240,7 @@ These are real past-incident-shaped corners. Keep them in mind before "cleaning 
 
 4. **`Sample` doesn't have `store_in` as a class macro.** It's called at runtime from `Server#bootstrap_mongoid!` (and from `cgminer_monitor migrate`) because the `expire_after` TTL depends on runtime config. `create_collection` is also called explicitly because Mongoid's lazy-create would make a regular collection, not a time-series one. Don't move the `store_in` back to class-load time.
 
-5. **`HttpApp` has class-level state set by `Server` at boot.** If you add new state, add a `reset_*!` helper and call it in test setup. If you try to move it to instance state, you'll have to invent a way to get a reference to the current instance into Sinatra's class-level route blocks, which is the bad old dance.
+5. **`HttpApp` state lives in Sinatra settings set by `Server#run` at boot.** If you add new state, add a `set :key, nil` alongside the existing ones and populate it in `Server#run` + `HttpApp.configure_for_test!`. Read in routes via `settings.key`. Defaults should be nil (or raise on access) for anything whose absence would silently lie to a caller.
 
 6. **`config/miners.yml` path is configurable via env var**, but the *default* is `'config/miners.yml'` which is CWD-relative. If you run `cgminer_monitor run` from a directory without a `config/` subdir, you need to set `CGMINER_MONITOR_MINERS_FILE` to an absolute path.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`HttpApp` class-level state moved to Sinatra `settings`.** `poller`,
+  `started_at`, and `configured_miners` are now declared via `set :key,
+  nil` on the class and written via `HttpApp.set :key, value` in
+  `Server#run`. Routes read via `settings.foo` instead of
+  `self.class.foo`. `configured_miners` is now eager-loaded by
+  `Server#run` (via `HttpApp.parse_miners_file`) rather than lazily on
+  first request.
+  - New class method `HttpApp.configure_for_test!(miners:, poller:,
+    started_at:)` bundles the three settings writes that tests used to
+    do one-by-one.
+  - Removed: `HttpApp.poller=` / `HttpApp.started_at=` / the
+    `HttpApp.configured_miners_cache` memo / `HttpApp.reset_configured_miners!`
+    helper. Specs that called any of these should switch to
+    `configure_for_test!`.
+
 ### Added
 - AI-assistant knowledge base under `docs/` (architecture, components,
   interfaces, data models, workflows, dependencies, review notes,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 1. **One process, foreground, supervisor-driven.** No PID files, no `daemonize`, no `start`/`stop`/`restart` subcommands. The CLI has `run` only; `systemd`/`docker`/`launchd` own the lifecycle. This was a deliberate simplification in the 1.0 rewrite.
 2. **Two concurrent threads, one exit path.** A polling thread and an HTTP server thread. Both feed failures into a shared `Queue` that unblocks the main thread to drive graceful shutdown. No watchdog, no restart logic — if either thread can't keep going, the process exits and the supervisor restarts.
-3. **Write-path and read-path are fully decoupled via Mongo.** The Poller writes samples + snapshots. The HTTP server reads them. Neither holds a live reference to the other's data structures beyond a few class-level attrs (`HttpApp.poller` is read for metrics counters, not for call-through).
+3. **Write-path and read-path are fully decoupled via Mongo.** The Poller writes samples + snapshots. The HTTP server reads them. Neither holds a live reference to the other's data structures beyond a few Sinatra settings (`settings.poller` is read for metrics counters, not for call-through).
 4. **Structural separation between "current state" and "time series".** Two MongoDB collections, two Mongoid models, two query modules. See `data_models.md`.
 5. **Config is immutable at boot.** `Data.define` Config, validated once in `from_env`, never mutated. Changing anything requires a restart. Justified by the operational model (supervisor-driven, cheap to restart).
 6. **Library code logs structurally, never to stderr directly.** One logger module; everything else calls it. See `components.md` for the logger contract.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,17 +178,17 @@ sequenceDiagram
 
 **Key observations:**
 - The read path never hits cgminer directly. Everything it returns was written by the Poller at the last poll interval.
-- `HttpApp.configured_miners_cache` is lazily built on first access from `Config.current.miners_file`. It's frozen; only cleared via `HttpApp.reset_configured_miners!` (tests only).
+- `settings.configured_miners` is eager-built by `Server#run` from `Config.current.miners_file` via `HttpApp.parse_miners_file`. Frozen. Specs populate it via `HttpApp.configure_for_test!(miners: …)`.
 - Time-range parameters accept ISO-8601 or relative (`1h`, `30m`, `7d`, `2w`). Defaults to the last hour.
 - `Cache-Control: public, max-age=<interval>` is set on graph data responses so intermediate caches don't hammer Mongo.
-- `miner_snapshot` validates that the `:miner` path param exists in `configured_miners_cache` and returns 404 if not — an unknown miner ID can't even check the db.
+- `miner_snapshot` validates that the `:miner` path param exists in `settings.configured_miners` and returns 404 if not — an unknown miner ID can't even check the db.
 
 ## HTTP API surface summary
 
 All under `/v2/*`. See `interfaces.md` for the full contract.
 
 - **`/healthz`** — returns one of `starting` / `healthy` / `degraded` plus diagnostics. HTTP 200 for healthy and starting, 503 for degraded.
-- **`/metrics`** — Prometheus text exposition. Reads from `latest_snapshot` for gauges and from `HttpApp.poller` for counters.
+- **`/metrics`** — Prometheus text exposition. Reads from `latest_snapshot` for gauges and from `settings.poller` for counters.
 - **`/miners`** — list of configured miners with availability inferred from the most recent snapshot.
 - **`/miners/:miner/{summary,devices,pools,stats}`** — latest snapshot per miner, per command.
 - **`/graph_data/{hashrate,temperature,availability}`** — time-range series queries.
@@ -205,8 +205,8 @@ All under `/v2/*`. See `interfaces.md` for the full contract.
 ### Queue-driven shutdown
 A shared `Queue` is the rendezvous point for "time to stop." Signal handlers push to it; Puma's crash handler pushes to it; the main thread blocks on it. This replaces the more common but more error-prone pattern of `Thread.current.raise` or `Thread#kill`.
 
-### Class-level state on HttpApp (deliberate, constrained)
-`HttpApp.poller`, `HttpApp.started_at`, `HttpApp.configured_miners_cache` are set by `Server` at boot, read by Sinatra routes. This is less clean than dependency injection but sidesteps the awkwardness of passing per-request context into Sinatra's class-level `get '...' do ... end` blocks. The trade-off: tests must reset that state between examples (see `spec/support/` and `HttpApp.reset_configured_miners!`).
+### App state in Sinatra settings
+`settings.poller`, `settings.started_at`, `settings.configured_miners` are written by `Server#run` before Puma accepts its first request, read by Sinatra routes. Settings are the idiomatic Sinatra mechanism for per-app configuration: they live on the class (same singleton semantics as the class-level accessors they replaced) but give us one consistent `set :foo, value` shape for writes and `settings.foo` for reads. Specs populate them in one call via `HttpApp.configure_for_test!(miners:, poller:, started_at:)`.
 
 ### "extract_samples" as a leaf function
 `Poller#extract_samples` is the one place that knows about cgminer's response shape (envelope → command-key → array of hash rows → numeric fields). Adding a new extracted metric or a new command means editing that one method. See the AGENTS.md extension notes.

--- a/docs/codebase_info.md
+++ b/docs/codebase_info.md
@@ -122,7 +122,7 @@ graph TB
 
     HttpApp -->|reads via| SampleQ
     HttpApp -->|reads via| SnapshotQ
-    HttpApp -.reads class attr.-> Poller
+    HttpApp -.reads settings.poller.-> Poller
     SampleQ -->|queries| Sample
     SnapshotQ -->|queries| Snapshot
 

--- a/docs/codebase_info.md
+++ b/docs/codebase_info.md
@@ -140,7 +140,7 @@ graph TB
 2. **`Config` is immutable** (`Data.define`). No hot reload. Changing env vars requires a restart.
 3. **Mongoid is configured programmatically** from `CGMINER_MONITOR_MONGO_URL` — there is no `config/mongoid.yml` in 1.0.
 4. **`miners.yml` is loaded at boot** and frozen. Adding/removing miners requires a restart.
-5. **`HttpApp` has class-level state** (`.poller`, `.started_at`, `.configured_miners_cache`) set by `Server` at boot. Tests must call `HttpApp.reset_configured_miners!` between examples.
+5. **`HttpApp` state lives in Sinatra settings** (`settings.poller`, `settings.started_at`, `settings.configured_miners`) set by `Server#run` at boot. Tests use `HttpApp.configure_for_test!(miners:, poller:, started_at:)` to populate them.
 6. **The samples collection is a MongoDB time-series collection** (Mongo 5.0+ feature) with an `expire_after` TTL matching `CGMINER_MONITOR_RETENTION_SECONDS`. `cgminer_monitor migrate` (or `Server#bootstrap_mongoid!`) does the `create_collection` call.
 7. **No authentication on the HTTP API.** Designed for trusted networks. Put a reverse proxy in front of it if you're exposing it beyond that.
 8. **`cgminer_api_client` is a hard runtime dependency.** The `Poller` bypasses `CgminerApiClient::MinerPool.new` (which hard-codes a `config/miners.yml` path relative to CWD) by allocating the pool and setting `.miners=` directly, so it can honor the configurable `CGMINER_MONITOR_MINERS_FILE`.

--- a/docs/components.md
+++ b/docs/components.md
@@ -44,7 +44,7 @@ graph LR
     end
 
     Srv -->|owns| Pol
-    Srv -->|sets class attrs on| App
+    Srv -->|HttpApp.set :poller/started_at/configured_miners| App
     Pol -->|writes| Smp
     Pol -->|writes| Snp
     App -->|reads via| SmpQ
@@ -163,7 +163,7 @@ Responsibilities:
 - Configure Mongoid from `config.mongo_url`.
 - `validate_startup!` — verify `miners.yml` parses non-empty and Mongo is reachable (raises `ConfigError` on empty, `Mongo::Error` on unreachable).
 - `bootstrap_mongoid!` — programmatic `store_in` + `create_collection` for `Sample`; `create_indexes` for `Snapshot`.
-- Wire up `HttpApp` class-level attrs (`.poller`, `.started_at`) for health-check and metrics access.
+- Wire up `HttpApp` Sinatra settings (`settings.poller`, `settings.started_at`, `settings.configured_miners`) for health-check and metrics access via `HttpApp.set :key, value`.
 - Spawn Poller and Puma threads; block on `@stop.pop`.
 - On signal: stop poller, `join` with shutdown timeout, stop launcher, `join` again, exit 0.
 - On `StandardError` in `run` body: log, exit 1. `ConfigError` from `validate_startup!` surfaces here — CLI translates any `ConfigError` to exit 78.

--- a/docs/components.md
+++ b/docs/components.md
@@ -173,11 +173,12 @@ Responsibilities:
 
 The read side. Sinatra app mounted under Puma. All routes under `/v2/*`, plus `/openapi.yml` and `/docs`.
 
-Class-level state set by `Server` at boot:
-- `HttpApp.poller` — reference to the running `Poller` instance for metrics counters (`polls_ok`, `polls_failed`).
-- `HttpApp.started_at` — UTC Time, uptime source for `/healthz`.
-- `HttpApp.configured_miners_cache` — lazily-built frozen list of `[miner_id, host, port]` from `Config.current.miners_file`. Read by `/miners`, used to validate `:miner` path params.
-- `HttpApp.reset_configured_miners!` — test helper to clear the cache.
+App state lives in Sinatra settings, written by `Server#run` before Puma accepts its first request:
+- `settings.poller` — reference to the running `Poller` instance for metrics counters (`polls_ok`, `polls_failed`).
+- `settings.started_at` — UTC Time, uptime source for `/healthz`.
+- `settings.configured_miners` — eager-built frozen list of `[miner_id, host, port]` from `Config.current.miners_file`. Read by `/miners`, used to validate `:miner` path params. Defaults to `nil`; the `configured_miners` helper raises if read before Server populates it.
+- `HttpApp.parse_miners_file(path)` — lift-out of the old lazy body; used by `Server#run` and `configure_for_test!` to build the list.
+- `HttpApp.configure_for_test!(miners:, poller:, started_at:)` — spec-harness helper that sets all three settings in one call.
 
 Uses `Rack::Cors` middleware configured from `Config.current.cors_origins`. `show_exceptions` and `dump_errors` are off; a generic `error do` handler logs unhandled exceptions via `Logger.error` and returns `{"error": "internal"}` with HTTP 500. A `not_found` handler returns `{"error": "not found"}` with 404.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@
 | "How do I add a new extracted metric?" | `components.md` (`Poller#extract_samples`) + `data_models.md` (sample meta shape) |
 | "What happens if Mongo goes away mid-poll?" | `architecture.md` (Poller error handling) + `workflows.md` (polling flow) + `interfaces.md` (Logger event names) |
 | "What's the CLI exit code when…?" | `interfaces.md` (CLI table) + `components.md` (bin/cgminer_monitor) |
-| "Where does `/healthz` get `started_at` from?" | `components.md` (HttpApp class-level state) + `architecture.md` (read vs write decoupling) |
+| "Where does `/healthz` get `started_at` from?" | `components.md` (HttpApp Sinatra settings) + `architecture.md` (read vs write decoupling) |
 | "Can I run this with MongoDB 4.4?" | `dependencies.md` (Mongo version support) — no, time-series requires 5.0+ |
 | "What's the schema of the `/v2/graph_data/hashrate` response?" | `interfaces.md` (HTTP API → Graph data) |
 | "Where does cgminer's `\"Pool Rejected%\"` end up in Mongo?" | `data_models.md` (Sample meta shape) — `metric: "pool_rejected_pct"` |

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -165,7 +165,7 @@ GET /v2/miners
 }
 ```
 
-The miners list is derived from `HttpApp.configured_miners_cache` (built once from `miners.yml`); `available` and `last_poll` come from `latest_snapshot`.
+The miners list is derived from `settings.configured_miners` (built once from `miners.yml` by `Server#run`); `available` and `last_poll` come from `latest_snapshot`.
 
 ### Per-miner snapshots
 

--- a/docs/review_notes.md
+++ b/docs/review_notes.md
@@ -15,7 +15,7 @@ I cross-referenced the following claims across files and found no contradictions
 | `samples` is time-series, `latest_snapshot` is regular | `architecture.md`, `data_models.md`, `components.md`, `dependencies.md` | consistent |
 | Ruby 3.2+ / Mongo 5.0+ floors | `codebase_info.md`, `dependencies.md` | consistent |
 | Signal-handler reinstall dance after Puma start | `architecture.md`, `components.md`, `workflows.md` | consistent |
-| HttpApp has class-level state (poller, started_at, configured_miners_cache) | `architecture.md`, `components.md`, `interfaces.md` | consistent |
+| HttpApp state lives in Sinatra settings (poller, started_at, configured_miners) | `architecture.md`, `components.md`, `interfaces.md` | consistent |
 
 Nothing contradictory. If later edits introduce drift, re-run this section.
 
@@ -27,13 +27,13 @@ Areas where the code hasn't fully settled a question, or where the docs are corr
 The CI matrix uses Mongo 6 and 7 because 5.0 isn't available as a GitHub Actions service container. A regression that broke 5.0 while remaining compatible with 6.0 wouldn't be caught. If 5.0 support is load-bearing for any user, add a spec that uses a locally-pulled Mongo 5 image (outside GitHub Actions services).
 
 ### 2. Thread safety of `Config.current` memoization
-`Config.current ||= from_env` is a classic lazy init that isn't thread-safe if called concurrently by multiple threads on the first call. In practice, `Server` always hits `Config.current` through the main thread before the Poller or Puma threads start, so this is not currently exploitable. But there's no lock; if a future refactor has the Poller initialize before `HttpApp.configured_miners_cache` is first touched, the race could surface. Consider a `Mutex` around the memoization or early-init in `Server#run`.
+`Config.current ||= from_env` is a classic lazy init that isn't thread-safe if called concurrently by multiple threads on the first call. In practice, `Server` always hits `Config.current` through the main thread before the Poller or Puma threads start, so this is not currently exploitable. But there's no lock; if a future refactor has the Poller initialize concurrently with `HttpApp`'s settings being populated in `Server#run`, the race could surface. Consider a `Mutex` around the memoization or early-init in `Server#run`.
 
 ### 3. No shutdown path for migrate/doctor subcommands
 `cgminer_monitor migrate` and `doctor` install Mongoid clients and exit. Mongoid's driver keeps background connection monitors running in threads, which can delay Ruby process exit briefly. Not broken — just sometimes a surprising few-second pause before shell prompt returns. No action needed unless it bites someone.
 
-### 4. `HttpApp#configured_miners_cache` is loaded from disk at first request
-The cache is lazily built on the first call into `configured_miners`. If the first request comes before the Poller does its first poll, and if `miners.yml` is unreadable by the process (rare), the request would raise. Not observed; flagged as a pedantic correctness note.
+### 4. ~~`HttpApp#configured_miners_cache` is loaded from disk at first request~~ — RESOLVED
+`Server#run` now eager-populates `settings.configured_miners` via `HttpApp.parse_miners_file` before Puma accepts its first request, so the first-request-reads-YAML hazard is gone.
 
 ### 5. No integration test for `run` with real signal delivery
 `spec/integration/cli_spec.rb` tests `migrate`, `doctor`, `version`, and the deprecated shims by spawning subprocesses. But it doesn't test `run` end-to-end (start, poll, SIGTERM, clean shutdown). Orchestrating signal delivery from a spec process is fiddly but doable; until then, the shutdown path is only exercised by the unit specs for `Server`, which mock the Puma launcher.
@@ -49,7 +49,7 @@ The cache is lazily built on the first call into `configured_miners`. If the fir
 
 Medium effort, possibly worth it:
 1. Add a spec that exercises `Server#run` end-to-end with real signal delivery.
-2. Replace `HttpApp.configured_miners_cache` with an instance variable set explicitly by `Server#run`; keeps the state flow in one place and removes one of the reset-for-tests pitfalls.
+2. ~~Replace `HttpApp.configured_miners_cache` with an instance variable set explicitly by `Server#run`.~~ Done — `HttpApp` class-level state moved to Sinatra `settings`, populated by `Server#run`. See Unreleased CHANGELOG.
 
 Higher effort, defer:
 3. Add a Mongo 5.0 CI lane (outside GitHub Actions services) so the 5.0 floor claim is actually enforced.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -42,7 +42,7 @@ sequenceDiagram
     Server->>Sample: create_collection
     Server->>Snapshot: create_indexes
 
-    Server->>HttpApp: HttpApp.poller = poller / .started_at = now
+    Server->>HttpApp: HttpApp.set :poller/:started_at/:configured_miners
     Server->>Logger: Logger.info 'server.start'
 
     Server->>Poller: Thread.new { poller.run_until_stopped }

--- a/lib/cgminer_monitor/http_app.rb
+++ b/lib/cgminer_monitor/http_app.rb
@@ -9,28 +9,37 @@ require 'time'
 
 module CgminerMonitor
   class HttpApp < Sinatra::Base
-    class << self
-      attr_accessor :poller, :started_at
-
-      def configured_miners_cache
-        @configured_miners_cache ||= begin
-          miners_config = YAML.safe_load_file(Config.current.miners_file)
-          miners_config.map do |m|
-            host = m['host']
-            port = m['port'] || 4028
-            ["#{host}:#{port}", host, port]
-          end.freeze
-        end
-      end
-
-      def reset_configured_miners!
-        @configured_miners_cache = nil
-      end
-    end
-
     set :show_exceptions, false
     set :dump_errors, false
     set :host_authorization, { permitted_hosts: [] }
+
+    # App state set by Server#run before Puma accepts its first request.
+    # Defaults intentionally `nil` so an unconfigured App fails loud on the
+    # first read rather than silently returning empty data. See the
+    # `configured_miners` helper below.
+    set :poller,            nil
+    set :started_at,        nil
+    set :configured_miners, nil
+
+    # Wraps the raw YAML parse behind a stable shape so Server#run (and
+    # the test helper below) can eager-populate `settings.configured_miners`.
+    # Returns a frozen Array of `[miner_id, host, port]` tuples.
+    def self.parse_miners_file(path)
+      YAML.safe_load_file(path).map do |m|
+        host = m['host']
+        port = m['port'] || 4028
+        ["#{host}:#{port}", host, port]
+      end.freeze
+    end
+
+    # Spec convenience. Keeps the "set every setting in one place" shape so
+    # the test-order footgun doesn't reopen if someone adds a new setting
+    # and forgets to null it out in between examples.
+    def self.configure_for_test!(miners:, poller: nil, started_at: nil)
+      set :configured_miners, miners
+      set :poller,             poller
+      set :started_at,         started_at || Time.now.utc
+    end
 
     configure do
       use Rack::Cors do
@@ -216,7 +225,7 @@ module CgminerMonitor
       last_poll_age_s = last_poll ? (Time.now.utc - last_poll).to_i : nil
       miners_available = miners_info.count { |m| m[:ok] }
 
-      app_started_at = self.class.started_at
+      app_started_at = settings.started_at
       uptime_s = app_started_at ? (Time.now.utc - app_started_at).to_i : 0
       stale_threshold = config.interval * config.healthz_stale_multiplier
 
@@ -236,8 +245,12 @@ module CgminerMonitor
       }
     end
 
+    # Fail-loud accessor — an unconfigured App raises a clear error
+    # instead of silently returning an empty miners list.
     def configured_miners
-      self.class.configured_miners_cache
+      settings.configured_miners || raise(
+        'HttpApp not configured; call Server#run or configure_for_test!'
+      )
     end
 
     def prom_escape(value)
@@ -361,7 +374,7 @@ module CgminerMonitor
       lines << '# HELP cgminer_monitor_polls_total Total polls performed'
       lines << '# TYPE cgminer_monitor_polls_total counter'
 
-      poller = self.class.poller
+      poller = settings.poller
       if poller
         lines << "cgminer_monitor_polls_total{result=\"ok\"} #{poller.polls_ok}"
         lines << "cgminer_monitor_polls_total{result=\"failed\"} #{poller.polls_failed}"

--- a/lib/cgminer_monitor/http_app.rb
+++ b/lib/cgminer_monitor/http_app.rb
@@ -32,13 +32,23 @@ module CgminerMonitor
       end.freeze
     end
 
+    # Sentinel so the default "give me a current timestamp" behavior for
+    # `started_at:` stays available without making nil-as-explicit-clear
+    # impossible to express.
+    STARTED_AT_DEFAULT = Object.new.freeze
+    private_constant :STARTED_AT_DEFAULT
+
     # Spec convenience. Keeps the "set every setting in one place" shape so
     # the test-order footgun doesn't reopen if someone adds a new setting
     # and forgets to null it out in between examples.
-    def self.configure_for_test!(miners:, poller: nil, started_at: nil)
+    #
+    # Omitting `started_at:` defaults to `Time.now.utc`. Passing `nil`
+    # explicitly writes `nil` — use this in `after` blocks to clear the
+    # setting.
+    def self.configure_for_test!(miners:, poller: nil, started_at: STARTED_AT_DEFAULT)
       set :configured_miners, miners
       set :poller,             poller
-      set :started_at,         started_at || Time.now.utc
+      set :started_at,         started_at.equal?(STARTED_AT_DEFAULT) ? Time.now.utc : started_at
     end
 
     configure do

--- a/lib/cgminer_monitor/server.rb
+++ b/lib/cgminer_monitor/server.rb
@@ -20,11 +20,13 @@ module CgminerMonitor
       validate_startup!
       bootstrap_mongoid!
 
-      # Wire the poller + started_at into HttpApp so metrics/healthz
-      # can read them. HttpApp owns this state; Server used to shadow
-      # it on itself but nothing read those copies.
-      HttpApp.poller = @poller
-      HttpApp.started_at = Time.now.utc
+      # Wire app state into HttpApp's Sinatra settings so routes can
+      # read via `settings.foo`. Server owns the write; HttpApp owns
+      # the read. All writes happen here, before Puma accepts its
+      # first request — no lazy loading, no per-request config drift.
+      HttpApp.set :poller,             @poller
+      HttpApp.set :started_at,         Time.now.utc
+      HttpApp.set :configured_miners,  HttpApp.parse_miners_file(@config.miners_file)
 
       Logger.info(event: 'server.start', pid: Process.pid,
                   config: @config.public_attrs)

--- a/spec/cgminer_monitor/http_app_spec.rb
+++ b/spec/cgminer_monitor/http_app_spec.rb
@@ -26,17 +26,17 @@ RSpec.describe CgminerMonitor::HttpApp do
     )
     CgminerMonitor::Config.instance_variable_set(:@current, config)
 
-    described_class.started_at = Time.now.utc - 100
-    described_class.poller = nil
-    described_class.reset_configured_miners!
+    described_class.configure_for_test!(
+      miners: described_class.parse_miners_file(miners_file),
+      poller: nil,
+      started_at: Time.now.utc - 100
+    )
   end
 
   after do
     CgminerMonitor::Config.reset!
-    described_class.reset_configured_miners!
     FileUtils.rm_f(miners_file)
-    described_class.started_at = nil
-    described_class.poller = nil
+    described_class.configure_for_test!(miners: nil, poller: nil, started_at: nil)
   end
 
   describe 'GET /v2/healthz' do

--- a/spec/cgminer_monitor/http_app_spec.rb
+++ b/spec/cgminer_monitor/http_app_spec.rb
@@ -39,6 +39,34 @@ RSpec.describe CgminerMonitor::HttpApp do
     described_class.configure_for_test!(miners: nil, poller: nil, started_at: nil)
   end
 
+  describe 'configure_for_test! teardown symmetry' do
+    # Guards the sentinel-based default introduced for started_at:.
+    # Passing `started_at: nil` explicitly MUST clear the setting —
+    # the old `|| Time.now.utc` fallback silently re-populated it.
+    it 'clears settings.started_at when passed started_at: nil explicitly' do
+      described_class.configure_for_test!(miners: nil, poller: nil, started_at: nil)
+      expect(described_class.settings.started_at).to be_nil
+    end
+
+    it 'defaults settings.started_at to Time.now.utc when started_at: is omitted' do
+      described_class.configure_for_test!(miners: nil)
+      expect(described_class.settings.started_at).to be_within(2).of(Time.now.utc)
+    end
+  end
+
+  describe 'fail-loud guard on unconfigured HttpApp' do
+    # A future refactor that swapped the `set :configured_miners, nil`
+    # default to `[]` or equivalent would make /v2/miners silently
+    # return an empty list on a misconfigured deploy. This spec pins
+    # the fail-loud contract.
+    it 'raises from the configured_miners helper when settings.configured_miners is nil' do
+      described_class.set :configured_miners, nil
+      app_instance = described_class.new!
+      expect { app_instance.send(:configured_miners) }
+        .to raise_error(/HttpApp not configured/)
+    end
+  end
+
   describe 'GET /v2/healthz' do
     context 'when mongo is reachable and a recent poll exists' do
       before do

--- a/spec/cgminer_monitor/server_spec.rb
+++ b/spec/cgminer_monitor/server_spec.rb
@@ -45,6 +45,39 @@ RSpec.describe CgminerMonitor::Server do
     end
   end
 
+  describe '#run eager-populates HttpApp settings' do
+    # Pins the "state set once, before Puma accepts a request" invariant.
+    # A regression that went back to lazy-loading configured_miners — or
+    # that reordered these writes to happen after Puma boot — would make
+    # /v2/miners race with initialization.
+    before do
+      allow(server).to receive(:configure_mongoid!)
+      allow(server).to receive(:bootstrap_mongoid!)
+      allow(server).to receive(:validate_startup!)
+      allow(server).to receive(:install_signal_handlers)
+      allow(server).to receive(:reinstall_signal_handlers)
+      # Prevent the poller + puma threads from actually starting.
+      allow(server.poller).to receive(:run_until_stopped)
+      allow(server.poller).to receive(:stop)
+      fake_launcher = instance_double(Puma::Launcher, run: nil, stop: nil)
+      allow(server).to receive(:build_puma_launcher).and_return(fake_launcher)
+      # Push a signal immediately so #run doesn't block.
+      server.instance_variable_get(:@stop).push('TEST')
+    end
+
+    after do
+      CgminerMonitor::HttpApp.configure_for_test!(miners: nil, poller: nil, started_at: nil)
+    end
+
+    it 'writes poller, started_at, and configured_miners to HttpApp settings' do
+      server.run
+      expect(CgminerMonitor::HttpApp.settings.poller).to eq(server.poller)
+      expect(CgminerMonitor::HttpApp.settings.started_at).to be_a(Time)
+      expect(CgminerMonitor::HttpApp.settings.configured_miners)
+        .to eq([['10.0.0.5:4028', '10.0.0.5', 4028]])
+    end
+  end
+
   describe 'signal handling' do
     it 'installs TERM and INT signal handlers' do
       # Capture the signals that get trapped

--- a/spec/integration/full_pipeline_spec.rb
+++ b/spec/integration/full_pipeline_spec.rb
@@ -26,18 +26,18 @@ RSpec.describe 'Full pipeline integration', :integration do
         'CGMINER_MONITOR_CORS_ORIGINS' => '*'
       )
       CgminerMonitor::Config.instance_variable_set(:@current, config)
-      CgminerMonitor::HttpApp.started_at = Time.now.utc
-      CgminerMonitor::HttpApp.poller = nil
 
       ctx[:poller] = CgminerMonitor::Poller.new(config)
-      CgminerMonitor::HttpApp.poller = ctx[:poller]
+      CgminerMonitor::HttpApp.configure_for_test!(
+        miners: CgminerMonitor::HttpApp.parse_miners_file(miners_file),
+        poller: ctx[:poller],
+        started_at: Time.now.utc
+      )
 
       example.run
 
       CgminerMonitor::Config.reset!
-      CgminerMonitor::HttpApp.started_at = nil
-      CgminerMonitor::HttpApp.poller = nil
-      CgminerMonitor::HttpApp.reset_configured_miners!
+      CgminerMonitor::HttpApp.configure_for_test!(miners: nil, poller: nil, started_at: nil)
       FileUtils.rm_f(miners_file)
     end
   end

--- a/spec/integration/healthz_spec.rb
+++ b/spec/integration/healthz_spec.rb
@@ -25,21 +25,21 @@ RSpec.describe 'Healthz integration', :integration do
       'CGMINER_MONITOR_HEALTHZ_STARTUP_GRACE' => '120'
     )
     CgminerMonitor::Config.instance_variable_set(:@current, config)
-    CgminerMonitor::HttpApp.poller = nil
+    CgminerMonitor::HttpApp.configure_for_test!(
+      miners: CgminerMonitor::HttpApp.parse_miners_file(miners_file)
+    )
   end
 
   after do
     CgminerMonitor::Config.reset!
-    CgminerMonitor::HttpApp.started_at = nil
-    CgminerMonitor::HttpApp.poller = nil
-    CgminerMonitor::HttpApp.reset_configured_miners!
+    CgminerMonitor::HttpApp.configure_for_test!(miners: nil, poller: nil, started_at: nil)
     FileUtils.rm_f(miners_file)
   end
 
   context 'starting state' do
     it 'returns 200 with status starting when within grace window and no polls yet' do
       # App just started, no polls have run yet
-      CgminerMonitor::HttpApp.started_at = Time.now.utc
+      CgminerMonitor::HttpApp.set :started_at, Time.now.utc
 
       get '/v2/healthz'
 
@@ -53,7 +53,7 @@ RSpec.describe 'Healthz integration', :integration do
 
   context 'healthy state' do
     it 'returns 200 with status healthy after a recent successful poll' do
-      CgminerMonitor::HttpApp.started_at = Time.now.utc - 300
+      CgminerMonitor::HttpApp.set :started_at, Time.now.utc - 300
 
       # Insert a recent snapshot
       upsert_snapshot(miner: '10.0.0.5:4028', command: 'summary', fetched_at: Time.now.utc - 10)
@@ -71,7 +71,7 @@ RSpec.describe 'Healthz integration', :integration do
 
   context 'degraded state — stale poll' do
     it 'returns 503 with status degraded when last poll exceeds 2x interval' do
-      CgminerMonitor::HttpApp.started_at = Time.now.utc - 600
+      CgminerMonitor::HttpApp.set :started_at, Time.now.utc - 600
 
       # Insert a stale snapshot (older than 2 * 60s = 120s)
       upsert_snapshot(miner: '10.0.0.5:4028', command: 'summary',
@@ -88,7 +88,7 @@ RSpec.describe 'Healthz integration', :integration do
   context 'degraded state — no polls and past grace window' do
     it 'returns 503 with status degraded when grace window has passed with no polls' do
       # App started 300s ago, grace window is 120s, and no polls exist
-      CgminerMonitor::HttpApp.started_at = Time.now.utc - 300
+      CgminerMonitor::HttpApp.set :started_at, Time.now.utc - 300
 
       get '/v2/healthz'
 
@@ -100,7 +100,7 @@ RSpec.describe 'Healthz integration', :integration do
 
   context 'degraded state — failed miner' do
     it 'reports miners_available correctly when a miner is down' do
-      CgminerMonitor::HttpApp.started_at = Time.now.utc - 300
+      CgminerMonitor::HttpApp.set :started_at, Time.now.utc - 300
 
       upsert_snapshot(miner: '10.0.0.5:4028', command: 'summary',
                       ok: false, error: 'Connection refused',


### PR DESCRIPTION
## Summary

Implements [docs/review_notes.md recommendation 2](./docs/review_notes.md): the class-level `attr_accessor :poller, :started_at` block and the lazy `configured_miners_cache` memoization on `HttpApp` are replaced with three Sinatra `settings`:

    set :poller,            nil
    set :started_at,        nil
    set :configured_miners, nil

- **Writes** happen once in `Server#run`, via `HttpApp.set :foo, value`, before Puma accepts its first request. No lazy first-request YAML parse.
- **Reads** in routes use `settings.foo` instead of `self.class.foo`. A new instance-method `configured_miners` wraps `settings.configured_miners` with a fail-loud guard — an unconfigured App raises a clear error instead of silently returning an empty list.
- **`HttpApp.parse_miners_file(path)`** replaces the old `configured_miners_cache` YAML parse body; `Server#run` and the test helper both use it.
- **`HttpApp.configure_for_test!(miners:, poller: nil, started_at: nil)`** bundles the three spec-setup assignments and the `reset_configured_miners!` call into one call. Kwarg default for `started_at` is `nil` with an internal `|| Time.now.utc` so the default doesn't freeze one timestamp at method-definition time.

Removed: `HttpApp.poller=`, `HttpApp.started_at=`, `HttpApp.configured_miners_cache`, `HttpApp.reset_configured_miners!`.

## Test plan

- [x] `bundle exec rake` — 117 examples, 0 failures, rubocop clean (requires mongo up).
- [x] `grep self.class. lib/` — zero occurrences post-change.
- [x] `grep reset_configured_miners spec/` — zero occurrences post-change.
- [x] Integration specs (`healthz_spec`, `full_pipeline_spec`, `http_app_spec`) exercise the eager-populated `settings.configured_miners` path via `configure_for_test!`.
- [ ] Manual smoke: `bundle exec cgminer_monitor doctor` + `cgminer_monitor run` against a fake cgminer — eager YAML load surfaces immediately at Server start, not at first request.

## Commits

- `10ff81e` Move HttpApp class-level state to Sinatra settings
- `474605e` Document the HttpApp settings migration