### PR TITLE
feat: hot-reload miners.yml via SIGHUP (+ reload CLI verb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`miners.yml` hot reload via SIGHUP.** Add or remove a miner without
+  restarting the service. The Server traps SIGHUP, atomically rebuilds
+  the Poller's `MinerPool` and swaps `HttpApp.settings.configured_miners`
+  — the next poll tick and every subsequent HTTP request see the new
+  list. Parse or validation failures log `event=reload.failed` and
+  keep the previous list so a typo can't crash a running server. New
+  CLI verb `cgminer_monitor reload` reads `CGMINER_MONITOR_PID_FILE`,
+  dry-run-parses miners.yml locally (surfacing typos at exit 78 before
+  signaling), and sends SIGHUP; `doctor` reports the PID file's
+  posture (`not configured` / `OK (pid N)` / `STALE` / `MISSING`).
+
 ### Changed
+- **Server signal dispatcher uses `launcher.events.on_booted` instead
+  of `sleep(0.05)`.** Puma's `setup_signals` unconditionally installs
+  its own SIGHUP handler that calls `stop()` when `stdout_redirect` is
+  unset; the old sleep-based wait could race and leave Puma's HUP
+  handler active, eating reload signals. `on_booted` is deterministic.
+  Shutdown (SIGTERM/SIGINT) behavior unchanged.
 - **`HttpApp` class-level state moved to Sinatra `settings`.** `poller`,
   `started_at`, and `configured_miners` are now declared via `set :key,
   nil` on the class and written via `HttpApp.set :key, value` in

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ All configuration is via environment variables. No config files are needed excep
 | `CGMINER_MONITOR_SHUTDOWN_TIMEOUT` | `10` | Graceful shutdown timeout in seconds |
 | `CGMINER_MONITOR_HEALTHZ_STALE_MULTIPLIER` | `2` | Multiplier on interval for stale-poll detection |
 | `CGMINER_MONITOR_HEALTHZ_STARTUP_GRACE` | `60` | Seconds to allow before first poll is expected |
+| `CGMINER_MONITOR_PID_FILE` | unset | Path where `run` writes the server PID on boot and unlinks on shutdown. Required for `cgminer_monitor reload`; operators can also `kill -HUP <pid>` directly. |
 
 ### Miners file
 
@@ -86,6 +87,17 @@ cgminer_monitor run
 ```
 
 The service runs in the foreground. Use your process supervisor (systemd, launchd, etc.) for production.
+
+### Hot-reloading miners.yml
+
+`miners.yml` is hot-reloadable — edit the file, then either
+`kill -HUP $(cat $CGMINER_MONITOR_PID_FILE)` or
+`cgminer_monitor reload`. The service logs `event=reload.ok` on
+success or `event=reload.failed` (and keeps the old list) if the new
+file fails to parse. Both the poll loop and the HTTP routes pick up
+the new list atomically. Only `miners.yml` reloads; changes to
+`CGMINER_MONITOR_MONGO_URL`, `CGMINER_MONITOR_INTERVAL`, log level,
+etc. still require a restart.
 
 ### Running with Docker
 

--- a/bin/cgminer_monitor
+++ b/bin/cgminer_monitor
@@ -101,6 +101,13 @@ when 'reload'
   rescue Errno::ESRCH
     warn "stale pid file (pid not running): #{pid_path}"
     exit 1
+  rescue Errno::EPERM
+    warn "pid #{pid} exists but is not owned by us " \
+         "(stale pid file from a different user? #{pid_path})"
+    exit 1
+  rescue ArgumentError
+    warn "pid file is not an integer: #{pid_path}"
+    exit 1
   end
 
 when 'doctor'
@@ -143,6 +150,8 @@ when 'doctor'
       puts "  INVALID: contents not an integer: #{pid_path}"
     rescue Errno::ESRCH
       puts "  STALE: pid #{recorded_pid} in #{pid_path} is not running"
+    rescue Errno::EPERM
+      puts "  UNOWNED: pid #{recorded_pid} in #{pid_path} exists but is not owned by us"
     end
   end
 

--- a/bin/cgminer_monitor
+++ b/bin/cgminer_monitor
@@ -63,6 +63,46 @@ when 'migrate'
     exit 1
   end
 
+when 'reload'
+  begin
+    config = CgminerMonitor::Config.from_env
+    CgminerMonitor::Logger.format = config.log_format
+    CgminerMonitor::Logger.level  = config.log_level
+
+    pid_path = config.pid_file
+    if pid_path.nil? || pid_path.empty?
+      warn 'CGMINER_MONITOR_PID_FILE not set; cannot locate running server'
+      exit 78
+    end
+
+    # Dry-run parse so YAML typos surface at the operator's terminal
+    # (exit 78 via ConfigError rescue below) instead of landing in the
+    # server's logs. Raises Psych::SyntaxError on malformed YAML;
+    # translate to ConfigError so the rescue keeps a uniform shape.
+    begin
+      CgminerMonitor::HttpApp.parse_miners_file(config.miners_file)
+    rescue Psych::SyntaxError => e
+      raise CgminerMonitor::ConfigError, "miners_file is not valid YAML: #{e.message}"
+    end
+
+    unless File.exist?(pid_path)
+      warn "pid file not found: #{pid_path} " \
+           "(server may still be starting — pid file is written after Puma boots)"
+      exit 1
+    end
+
+    pid = Integer(File.read(pid_path).strip)
+    Process.kill(0, pid)
+    Process.kill('HUP', pid)
+    puts "SIGHUP sent to pid #{pid}; check server logs for reload.ok"
+  rescue CgminerMonitor::ConfigError => e
+    warn "Configuration error: #{e.message}"
+    exit 78
+  rescue Errno::ESRCH
+    warn "stale pid file (pid not running): #{pid_path}"
+    exit 1
+  end
+
 when 'doctor'
   config = CgminerMonitor::Config.from_env
   puts "cgminer_monitor #{CgminerMonitor::VERSION}"
@@ -83,6 +123,27 @@ when 'doctor'
     puts 'OK'
   rescue StandardError => e
     puts "FAILED: #{e.class}: #{e.message}"
+  end
+
+  # Check PID file posture — audit-honest report so an operator knows
+  # whether `cgminer_monitor reload` will work.
+  puts ''
+  puts 'PID file:'
+  pid_path = config.pid_file
+  if pid_path.nil? || pid_path.empty?
+    puts '  not configured (reload verb unavailable; use kill -HUP <pid> directly)'
+  elsif !File.exist?(pid_path)
+    puts "  MISSING: configured but absent: #{pid_path}"
+  else
+    begin
+      recorded_pid = Integer(File.read(pid_path).strip)
+      Process.kill(0, recorded_pid)
+      puts "  OK: #{pid_path} (pid #{recorded_pid})"
+    rescue ArgumentError
+      puts "  INVALID: contents not an integer: #{pid_path}"
+    rescue Errno::ESRCH
+      puts "  STALE: pid #{recorded_pid} in #{pid_path} is not running"
+    end
   end
 
   # Check miners
@@ -126,6 +187,7 @@ when nil
   warn "  run       Run the monitoring service in the foreground"
   warn "  migrate   Create MongoDB collections and indexes (idempotent)"
   warn "  doctor    Validate config, test Mongo + miner connectivity"
+  warn "  reload    Dry-run-parse miners.yml, then SIGHUP the running server"
   warn "  version   Print version and exit"
   exit 64
 

--- a/lib/cgminer_monitor/config.rb
+++ b/lib/cgminer_monitor/config.rb
@@ -11,7 +11,8 @@ module CgminerMonitor
     :cors_origins,
     :shutdown_timeout,
     :healthz_stale_multiplier,
-    :healthz_startup_grace_seconds
+    :healthz_startup_grace_seconds,
+    :pid_file
   ) do
     def validate!
       raise ConfigError, "interval must be > 0" unless interval.positive?
@@ -50,7 +51,8 @@ module CgminerMonitor
         cors_origins: env.fetch("CGMINER_MONITOR_CORS_ORIGINS", "*"),
         shutdown_timeout: parse_int(env, "CGMINER_MONITOR_SHUTDOWN_TIMEOUT", "10"),
         healthz_stale_multiplier: parse_int(env, "CGMINER_MONITOR_HEALTHZ_STALE_MULTIPLIER", "2"),
-        healthz_startup_grace_seconds: parse_int(env, "CGMINER_MONITOR_HEALTHZ_STARTUP_GRACE", "60")
+        healthz_startup_grace_seconds: parse_int(env, "CGMINER_MONITOR_HEALTHZ_STARTUP_GRACE", "60"),
+        pid_file: env["CGMINER_MONITOR_PID_FILE"]
       ).validate!
     end
 

--- a/lib/cgminer_monitor/http_app.rb
+++ b/lib/cgminer_monitor/http_app.rb
@@ -32,6 +32,23 @@ module CgminerMonitor
       end.freeze
     end
 
+    # Re-parses the given miners file and atomically swaps
+    # `settings.configured_miners`. Returns the new miner count on
+    # success, nil on parse/IO failure — the old setting is untouched
+    # on failure so in-flight readers never see a torn state. Caught
+    # failure modes: missing file, malformed YAML, and a top-level
+    # scalar (which makes `YAML.safe_load_file(path).map` raise
+    # NoMethodError because String lacks #map).
+    def self.reload_miners!(path)
+      new_miners = parse_miners_file(path)
+      set :configured_miners, new_miners
+      new_miners.size
+    rescue Errno::ENOENT, Psych::SyntaxError, NoMethodError => e
+      Logger.warn(event: 'reload.failed',
+                  error: e.class.to_s, message: e.message)
+      nil
+    end
+
     # Sentinel so the default "give me a current timestamp" behavior for
     # `started_at:` stays available without making nil-as-explicit-clear
     # impossible to express.

--- a/lib/cgminer_monitor/http_app.rb
+++ b/lib/cgminer_monitor/http_app.rb
@@ -23,27 +23,37 @@ module CgminerMonitor
 
     # Wraps the raw YAML parse behind a stable shape so Server#run (and
     # the test helper below) can eager-populate `settings.configured_miners`.
-    # Returns a frozen Array of `[miner_id, host, port]` tuples.
+    # Returns a frozen Array of `[miner_id, host, port]` tuples. Raises
+    # ConfigError on shape errors (non-Array top level, list entry not
+    # a Hash, or Hash missing `host`) so callers don't have to rescue
+    # NoMethodError/TypeError just to distinguish "malformed miners
+    # file" from "bug in our code."
     def self.parse_miners_file(path)
-      YAML.safe_load_file(path).map do |m|
+      raw = YAML.safe_load_file(path)
+      validate_miners_shape!(path, raw)
+      raw.map do |m|
         host = m['host']
         port = m['port'] || 4028
         ["#{host}:#{port}", host, port]
       end.freeze
     end
 
+    def self.validate_miners_shape!(path, raw)
+      return if raw.is_a?(Array) && raw.all? { |m| m.is_a?(Hash) && m['host'] }
+
+      raise ConfigError, "#{path} must be a YAML list of {host, port} entries"
+    end
+    private_class_method :validate_miners_shape!
+
     # Re-parses the given miners file and atomically swaps
     # `settings.configured_miners`. Returns the new miner count on
-    # success, nil on parse/IO failure — the old setting is untouched
-    # on failure so in-flight readers never see a torn state. Caught
-    # failure modes: missing file, malformed YAML, and a top-level
-    # scalar (which makes `YAML.safe_load_file(path).map` raise
-    # NoMethodError because String lacks #map).
+    # success, nil on parse/validation/IO failure — the old setting is
+    # untouched on failure so in-flight readers never see a torn state.
     def self.reload_miners!(path)
       new_miners = parse_miners_file(path)
       set :configured_miners, new_miners
       new_miners.size
-    rescue Errno::ENOENT, Psych::SyntaxError, NoMethodError => e
+    rescue ConfigError, Errno::ENOENT, Psych::SyntaxError => e
       Logger.warn(event: 'reload.failed',
                   error: e.class.to_s, message: e.message)
       nil

--- a/lib/cgminer_monitor/poller.rb
+++ b/lib/cgminer_monitor/poller.rb
@@ -19,12 +19,17 @@ module CgminerMonitor
     end
 
     def poll_once
+      # Capture @miner_pool once so a mid-poll reload! (which atomically
+      # swaps the ivar) can't mix miner_ids from the old list with query
+      # results from the new pool. Threading `pool` through poll_miner /
+      # query_command keeps the whole tick consistent.
+      pool         = @miner_pool
       now          = Time.now.utc
       all_samples  = []
       snapshot_ops = []
 
-      @miner_pool.miners.each do |miner|
-        poll_miner(miner, now, all_samples, snapshot_ops)
+      pool.miners.each do |miner|
+        poll_miner(pool, miner, now, all_samples, snapshot_ops)
       end
 
       write_samples(all_samples) unless all_samples.empty?
@@ -65,15 +70,32 @@ module CgminerMonitor
       @stopped
     end
 
+    # Rebuilds @miner_pool from `miners_file` by constructing a *new*
+    # MinerPool and swapping the ivar. Never mutates an existing pool's
+    # miners array in place — any in-flight poll_once has already
+    # captured the old pool as a local and would see a torn read if we
+    # mutated. MRI's GVL makes the `@miner_pool =` assignment atomic.
+    # Returns the new miner count on success, nil on parse/IO failure
+    # (old pool is untouched on failure).
+    def reload!(miners_file = @config.miners_file)
+      new_pool = build_miner_pool(miners_file)
+      @miner_pool = new_pool
+      new_pool.miners.size
+    rescue CgminerMonitor::ConfigError, Errno::ENOENT, Psych::SyntaxError, NoMethodError => e
+      Logger.warn(event: 'reload.failed',
+                  error: e.class.to_s, message: e.message)
+      nil
+    end
+
     private
 
-    def poll_miner(miner, now, all_samples, snapshot_ops)
+    def poll_miner(pool, miner, now, all_samples, snapshot_ops)
       miner_id   = "#{miner.host}:#{miner.port}"
       started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       miner_ok   = true
 
       COMMANDS.each do |command|
-        pool_result  = query_command(command)
+        pool_result  = pool.query(command)
         miner_result = pool_result[miner_id]
 
         if miner_result&.ok?
@@ -118,10 +140,6 @@ module CgminerMonitor
     def append_synthetic_samples(miner_id, miner_ok, elapsed_ms, now, all_samples)
       all_samples << sample_hash(miner_id, 'poll', 0, 'ok', miner_ok ? 1.0 : 0.0, now)
       all_samples << sample_hash(miner_id, 'poll', 0, 'duration_ms', elapsed_ms, now)
-    end
-
-    def query_command(command)
-      @miner_pool.query(command)
     end
 
     def extract_samples(miner_id, command, response, ts)

--- a/lib/cgminer_monitor/poller.rb
+++ b/lib/cgminer_monitor/poller.rb
@@ -76,12 +76,15 @@ module CgminerMonitor
     # captured the old pool as a local and would see a torn read if we
     # mutated. MRI's GVL makes the `@miner_pool =` assignment atomic.
     # Returns the new miner count on success, nil on parse/IO failure
-    # (old pool is untouched on failure).
+    # (old pool is untouched on failure). The rescue list covers only
+    # named validation/IO failures from build_miner_pool — a bug like
+    # a method rename surfaces as an uncaught NoMethodError, which is
+    # what we want; don't broaden the rescue.
     def reload!(miners_file = @config.miners_file)
       new_pool = build_miner_pool(miners_file)
       @miner_pool = new_pool
       new_pool.miners.size
-    rescue CgminerMonitor::ConfigError, Errno::ENOENT, Psych::SyntaxError, NoMethodError => e
+    rescue CgminerMonitor::ConfigError, Errno::ENOENT, Psych::SyntaxError => e
       Logger.warn(event: 'reload.failed',
                   error: e.class.to_s, message: e.message)
       nil
@@ -209,6 +212,11 @@ module CgminerMonitor
       # to CWD via load_miners!. We bypass initialize with allocate and set
       # miners directly from the configurable miners_file path.
       miners_config = YAML.safe_load_file(miners_file)
+      unless miners_config.is_a?(Array) && miners_config.all? { |m| m.is_a?(Hash) && m['host'] }
+        raise CgminerMonitor::ConfigError,
+              "#{miners_file} must be a YAML list of {host, port} entries"
+      end
+
       pool          = CgminerApiClient::MinerPool.allocate
       pool.miners   = miners_config.collect do |miner|
         CgminerApiClient::Miner.new(miner['host'], miner['port'], miner['timeout'])

--- a/lib/cgminer_monitor/server.rb
+++ b/lib/cgminer_monitor/server.rb
@@ -133,19 +133,25 @@ module CgminerMonitor
 
     # Two-step reload: Poller holds the live MinerPool the poll loop
     # iterates; HttpApp holds the route-read miner list. Both must
-    # agree for a clean reload. If either fails we log reload.failed
-    # (inside the reload methods) and skip reload.ok so an operator
-    # sees the discrepancy in logs; the one-tick window where only one
-    # side has updated is cosmetic (we only get here if one side's
-    # parse raised but the other's succeeded, which requires an
-    # external TOCTOU file rewrite).
+    # agree for a clean reload. Each side logs reload.failed on its
+    # own parse failure; this dispatcher adds:
+    #   - reload.ok when both succeeded
+    #   - reload.partial when exactly one succeeded (inconsistent state
+    #     until the next reload; operator needs to know which half won)
+    #   - nothing when both failed (both reload.failed log lines are
+    #     enough signal; a dispatcher-level event would just duplicate)
     def perform_reload
       Logger.info(event: 'reload.signal_received')
       pool_count = @poller.reload!
       app_count  = HttpApp.reload_miners!(@config.miners_file)
-      return unless pool_count && app_count
 
-      Logger.info(event: 'reload.ok', miners: pool_count)
+      if pool_count && app_count
+        Logger.info(event: 'reload.ok', miners: pool_count)
+      elsif pool_count || app_count
+        Logger.error(event: 'reload.partial',
+                     poller_ok: !pool_count.nil?,
+                     http_app_ok: !app_count.nil?)
+      end
     end
 
     def write_pid_file

--- a/lib/cgminer_monitor/server.rb
+++ b/lib/cgminer_monitor/server.rb
@@ -9,9 +9,10 @@ module CgminerMonitor
     attr_reader :config, :poller
 
     def initialize(config)
-      @config = config
-      @poller = Poller.new(config)
-      @stop   = Queue.new
+      @config  = config
+      @poller  = Poller.new(config)
+      @signals = Queue.new
+      @booted  = Queue.new
     end
 
     def run
@@ -31,19 +32,25 @@ module CgminerMonitor
       Logger.info(event: 'server.start', pid: Process.pid,
                   config: @config.public_attrs)
 
-      poller_thread = Thread.new { @poller.run_until_stopped(@stop) }
+      poller_thread = Thread.new { @poller.run_until_stopped(@signals) }
       puma_launcher = build_puma_launcher
-      puma_thread = Thread.new do
-        puma_launcher.run
-      rescue Exception => e # rubocop:disable Lint/RescueException
-        Logger.error(event: 'puma.crash', error: e.class.to_s,
-                     message: e.message, backtrace: e.backtrace&.first(10))
-        @stop << 'puma_crash'
-      end
-      reinstall_signal_handlers # Re-install after Puma's setup_signals runs
+      puma_thread   = start_puma_thread(puma_launcher)
 
-      signal = @stop.pop # blocks until SIGTERM/SIGINT
-      Logger.info(event: 'server.stopping', signal: signal)
+      # Wait for Puma's launcher.events.on_booted before reinstalling
+      # our traps. Puma's setup_signals runs synchronously during
+      # launcher.run and overwrites our handlers — including
+      # installing its own SIGHUP trap (which calls stop() when
+      # stdout_redirect is unset), which would shut us down instead of
+      # triggering a reload. on_booted is deterministic; the previous
+      # sleep(0.05) was racy.
+      @booted.pop
+      install_signal_handlers
+
+      write_pid_file
+
+      dispatch_signals_until_stop
+
+      Logger.info(event: 'server.stopping')
 
       @poller.stop
       poller_thread.join(@config.shutdown_timeout)
@@ -56,6 +63,8 @@ module CgminerMonitor
       Logger.error(event: 'server.crash', error: e.class.to_s,
                    message: e.message, backtrace: e.backtrace)
       1
+    ensure
+      unlink_pid_file
     end
 
     # --- Startup ---
@@ -96,15 +105,68 @@ module CgminerMonitor
 
     private
 
-    def install_signal_handlers
-      %w[TERM INT].each do |sig|
-        Signal.trap(sig) { @stop << sig }
+    def start_puma_thread(launcher)
+      Thread.new do
+        launcher.run
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        Logger.error(event: 'puma.crash', error: e.class.to_s,
+                     message: e.message, backtrace: e.backtrace&.first(10))
+        @booted << true # unblock main if we died before booting
+        @signals << :stop
       end
+    end
+
+    def install_signal_handlers
+      Signal.trap('INT')  { @signals << :stop }
+      Signal.trap('TERM') { @signals << :stop }
+      Signal.trap('HUP')  { @signals << :reload }
+    end
+
+    def dispatch_signals_until_stop
+      loop do
+        case @signals.pop
+        when :reload then perform_reload
+        when :stop   then break
+        end
+      end
+    end
+
+    # Two-step reload: Poller holds the live MinerPool the poll loop
+    # iterates; HttpApp holds the route-read miner list. Both must
+    # agree for a clean reload. If either fails we log reload.failed
+    # (inside the reload methods) and skip reload.ok so an operator
+    # sees the discrepancy in logs; the one-tick window where only one
+    # side has updated is cosmetic (we only get here if one side's
+    # parse raised but the other's succeeded, which requires an
+    # external TOCTOU file rewrite).
+    def perform_reload
+      Logger.info(event: 'reload.signal_received')
+      pool_count = @poller.reload!
+      app_count  = HttpApp.reload_miners!(@config.miners_file)
+      return unless pool_count && app_count
+
+      Logger.info(event: 'reload.ok', miners: pool_count)
+    end
+
+    def write_pid_file
+      return unless @config.pid_file
+
+      File.write(@config.pid_file, "#{Process.pid}\n")
+      Logger.info(event: 'server.pid_file_written', path: @config.pid_file)
+    end
+
+    def unlink_pid_file
+      return unless @config.pid_file
+
+      File.unlink(@config.pid_file)
+    rescue Errno::ENOENT
+      # already gone — shutdown raced with external cleanup; fine
     end
 
     def build_puma_launcher
       app = HttpApp
       config = @config
+      booted = @booted
 
       puma_config = Puma::Configuration.new do |user_config|
         user_config.bind "tcp://#{config.http_host}:#{config.http_port}"
@@ -114,21 +176,14 @@ module CgminerMonitor
         user_config.log_requests false
         user_config.quiet
         # Prevent Puma from installing its own SIGTERM handler, which would
-        # overwrite our @stop-queue-based handler. We handle shutdown ourselves
+        # overwrite our @signals-queue-based handler. We handle shutdown ourselves
         # via launcher.stop called from the main thread.
         user_config.raise_exception_on_sigterm false
       end
 
-      Puma::Launcher.new(puma_config)
-    end
-
-    def reinstall_signal_handlers
-      # Puma::Launcher#run calls setup_signals synchronously, which overwrites
-      # process-global signal handlers. We re-install ours after a brief yield
-      # to let Puma's thread start. Even with raise_exception_on_sigterm false,
-      # Puma may still install handlers for other signals.
-      sleep 0.05
-      install_signal_handlers
+      launcher = Puma::Launcher.new(puma_config)
+      launcher.events.on_booted { booted << true }
+      launcher
     end
   end
 end

--- a/spec/cgminer_monitor/config_spec.rb
+++ b/spec/cgminer_monitor/config_spec.rb
@@ -58,6 +58,18 @@ RSpec.describe CgminerMonitor::Config do
       expect(config.healthz_startup_grace_seconds).to eq 90
     end
 
+    it 'reads CGMINER_MONITOR_PID_FILE when set' do
+      config = described_class.from_env(valid_env.merge(
+                                          'CGMINER_MONITOR_PID_FILE' => '/tmp/cm-monitor.pid'
+                                        ))
+      expect(config.pid_file).to eq('/tmp/cm-monitor.pid')
+    end
+
+    it 'leaves pid_file nil when CGMINER_MONITOR_PID_FILE unset' do
+      config = described_class.from_env(valid_env)
+      expect(config.pid_file).to be_nil
+    end
+
     it 'uses sensible defaults when env vars are not set' do
       config = described_class.from_env({ 'CGMINER_MONITOR_MINERS_FILE' => miners_file })
 

--- a/spec/cgminer_monitor/http_app_reload_spec.rb
+++ b/spec/cgminer_monitor/http_app_reload_spec.rb
@@ -47,4 +47,18 @@ RSpec.describe CgminerMonitor::HttpApp, '.reload_miners!' do # rubocop:disable R
     expect(described_class.reload_miners!(path)).to be_nil
     expect(described_class.settings.configured_miners).to equal(old)
   end
+
+  it 'keeps old miners when a list entry is a scalar (not a Hash)' do
+    old = described_class.settings.configured_miners
+    File.write(path, "- just-a-string\n")
+    expect(described_class.reload_miners!(path)).to be_nil
+    expect(described_class.settings.configured_miners).to equal(old)
+  end
+
+  it 'keeps old miners when a list entry is missing host' do
+    old = described_class.settings.configured_miners
+    File.write(path, "- port: 4028\n")
+    expect(described_class.reload_miners!(path)).to be_nil
+    expect(described_class.settings.configured_miners).to equal(old)
+  end
 end

--- a/spec/cgminer_monitor/http_app_reload_spec.rb
+++ b/spec/cgminer_monitor/http_app_reload_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+
+RSpec.describe CgminerMonitor::HttpApp, '.reload_miners!' do # rubocop:disable RSpec/SpecFilePathFormat
+  let(:dir)  { Dir.mktmpdir }
+  let(:path) { File.join(dir, 'miners.yml') }
+
+  before do
+    File.write(path, "- host: 10.0.0.1\n  port: 4028\n")
+    described_class.configure_for_test!(
+      miners: described_class.parse_miners_file(path)
+    )
+  end
+
+  after do
+    described_class.configure_for_test!(miners: nil, poller: nil, started_at: nil)
+    FileUtils.rm_rf(dir)
+  end
+
+  it 'swaps configured_miners with the freshly parsed file' do
+    File.write(path, "- host: 10.0.0.2\n  port: 4028\n")
+    expect(described_class.reload_miners!(path)).to eq(1)
+    expect(described_class.settings.configured_miners)
+      .to eq([['10.0.0.2:4028', '10.0.0.2', 4028]])
+  end
+
+  it 'keeps old miners and returns nil when YAML is malformed' do
+    old = described_class.settings.configured_miners
+    File.write(path, 'not: [valid')
+    expect(described_class.reload_miners!(path)).to be_nil
+    expect(described_class.settings.configured_miners).to equal(old)
+  end
+
+  it 'keeps old miners when file goes missing' do
+    old = described_class.settings.configured_miners
+    File.unlink(path)
+    expect(described_class.reload_miners!(path)).to be_nil
+    expect(described_class.settings.configured_miners).to equal(old)
+  end
+
+  it 'keeps old miners when the top-level YAML is not a list' do
+    old = described_class.settings.configured_miners
+    File.write(path, "just-a-scalar\n")
+    expect(described_class.reload_miners!(path)).to be_nil
+    expect(described_class.settings.configured_miners).to equal(old)
+  end
+end

--- a/spec/cgminer_monitor/poller_reload_spec.rb
+++ b/spec/cgminer_monitor/poller_reload_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+
+RSpec.describe CgminerMonitor::Poller, '#reload!' do
+  let(:dir)  { Dir.mktmpdir }
+  let(:path) { File.join(dir, 'miners.yml') }
+  let(:config) do
+    instance_double(CgminerMonitor::Config,
+                    miners_file: path,
+                    interval: 60,
+                    shutdown_timeout: 5)
+  end
+
+  before { File.write(path, "- host: 10.0.0.1\n  port: 4028\n") }
+  after  { FileUtils.rm_rf(dir) }
+
+  it 'rebuilds @miner_pool from the updated file' do
+    poller = described_class.new(config)
+    expect(poller.instance_variable_get(:@miner_pool).miners.map(&:host))
+      .to eq(['10.0.0.1'])
+
+    File.write(path, "- host: 10.0.0.2\n  port: 4028\n")
+    expect(poller.reload!).to eq(1)
+    expect(poller.instance_variable_get(:@miner_pool).miners.map(&:host))
+      .to eq(['10.0.0.2'])
+  end
+
+  it 'keeps the old pool on bad YAML' do
+    poller = described_class.new(config)
+    old = poller.instance_variable_get(:@miner_pool)
+    File.write(path, 'not: [valid')
+    expect(poller.reload!).to be_nil
+    expect(poller.instance_variable_get(:@miner_pool)).to equal(old)
+  end
+
+  it 'keeps the old pool when file is missing' do
+    poller = described_class.new(config)
+    old = poller.instance_variable_get(:@miner_pool)
+    File.unlink(path)
+    expect(poller.reload!).to be_nil
+    expect(poller.instance_variable_get(:@miner_pool)).to equal(old)
+  end
+end

--- a/spec/cgminer_monitor/poller_reload_spec.rb
+++ b/spec/cgminer_monitor/poller_reload_spec.rb
@@ -43,4 +43,46 @@ RSpec.describe CgminerMonitor::Poller, '#reload!' do
     expect(poller.reload!).to be_nil
     expect(poller.instance_variable_get(:@miner_pool)).to equal(old)
   end
+
+  # Core correctness invariant for the poll_once pool-capture refactor:
+  # a reload! that lands mid-tick must not divert subsequent pool.query
+  # calls in the same poll_once to the freshly-swapped pool. The
+  # capture at poll_once:26 and the threaded `pool` parameter down into
+  # poll_miner is what upholds this; a regression that re-reads
+  # @miner_pool inside poll_miner would silently break it and none of
+  # the other tests would notice.
+  it 'keeps querying the captured pool after a mid-tick reload!' do
+    poller = described_class.new(config)
+    original_pool = poller.instance_variable_get(:@miner_pool)
+    miner = original_pool.miners.first
+
+    # Replace build_miner_pool so reload! swaps in a distinct double.
+    new_pool = instance_double(CgminerApiClient::MinerPool, miners: [miner])
+    allow(poller).to receive(:build_miner_pool).and_return(new_pool)
+
+    miner_id = "#{miner.host}:#{miner.port}"
+    per_miner_result = instance_double(CgminerApiClient::MinerResult, ok?: false, error: StandardError.new('stub'))
+
+    # Original pool's first query call triggers the swap. All four
+    # subsequent pool.query calls in this tick must still hit
+    # `original_pool`, not `new_pool`.
+    call_count = 0
+    allow(original_pool).to receive(:query) do
+      call_count += 1
+      poller.reload! if call_count == 1 # swap happens after first query
+      { miner_id => per_miner_result }
+    end
+    allow(new_pool).to receive(:query).and_raise('new pool must not be queried in the same tick')
+
+    allow(poller).to receive(:write_snapshots)
+    allow(CgminerMonitor::Logger).to receive(:warn)
+    allow(CgminerMonitor::Logger).to receive(:info)
+
+    expect { poller.poll_once }.not_to raise_error
+
+    expect(call_count).to eq(CgminerMonitor::Poller::COMMANDS.size)
+    expect(new_pool).not_to have_received(:query)
+    # Sanity: reload! did land, ivar is now the new pool for the *next* tick.
+    expect(poller.instance_variable_get(:@miner_pool)).to equal(new_pool)
+  end
 end

--- a/spec/cgminer_monitor/server_signal_spec.rb
+++ b/spec/cgminer_monitor/server_signal_spec.rb
@@ -74,6 +74,56 @@ RSpec.describe CgminerMonitor::Server do
 
       expect(CgminerMonitor::Logger).not_to have_received(:info).with(hash_including(event: 'reload.ok'))
     end
+
+    it 'logs reload.partial when poller succeeds but HttpApp fails' do
+      poller = instance_double(CgminerMonitor::Poller, reload!: 3)
+      config = instance_double(CgminerMonitor::Config, miners_file: '/tmp/m.yml')
+      server = described_class.allocate
+      server.instance_variable_set(:@poller, poller)
+      server.instance_variable_set(:@config, config)
+
+      allow(CgminerMonitor::HttpApp).to receive(:reload_miners!).and_return(nil)
+      allow(CgminerMonitor::Logger).to receive(:info)
+      allow(CgminerMonitor::Logger).to receive(:error)
+
+      server.send(:perform_reload)
+
+      expect(CgminerMonitor::Logger).to have_received(:error)
+        .with(event: 'reload.partial', poller_ok: true, http_app_ok: false)
+    end
+
+    it 'logs reload.partial when HttpApp succeeds but poller fails' do
+      poller = instance_double(CgminerMonitor::Poller, reload!: nil)
+      config = instance_double(CgminerMonitor::Config, miners_file: '/tmp/m.yml')
+      server = described_class.allocate
+      server.instance_variable_set(:@poller, poller)
+      server.instance_variable_set(:@config, config)
+
+      allow(CgminerMonitor::HttpApp).to receive(:reload_miners!).and_return(3)
+      allow(CgminerMonitor::Logger).to receive(:info)
+      allow(CgminerMonitor::Logger).to receive(:error)
+
+      server.send(:perform_reload)
+
+      expect(CgminerMonitor::Logger).to have_received(:error)
+        .with(event: 'reload.partial', poller_ok: false, http_app_ok: true)
+    end
+
+    it 'does not log reload.partial when both sides fail' do
+      poller = instance_double(CgminerMonitor::Poller, reload!: nil)
+      config = instance_double(CgminerMonitor::Config, miners_file: '/tmp/m.yml')
+      server = described_class.allocate
+      server.instance_variable_set(:@poller, poller)
+      server.instance_variable_set(:@config, config)
+
+      allow(CgminerMonitor::HttpApp).to receive(:reload_miners!).and_return(nil)
+      allow(CgminerMonitor::Logger).to receive(:info)
+      allow(CgminerMonitor::Logger).to receive(:error)
+
+      server.send(:perform_reload)
+
+      expect(CgminerMonitor::Logger).not_to have_received(:error).with(hash_including(event: 'reload.partial'))
+    end
   end
 
   describe '#write_pid_file / #unlink_pid_file' do

--- a/spec/cgminer_monitor/server_signal_spec.rb
+++ b/spec/cgminer_monitor/server_signal_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CgminerMonitor::Server do
+  describe '#install_signal_handlers' do
+    it 'traps INT and TERM as :stop and HUP as :reload into @signals' do
+      server = described_class.allocate
+      server.instance_variable_set(:@config, instance_double(CgminerMonitor::Config))
+      server.instance_variable_set(:@signals, Queue.new)
+
+      trapped = {}
+      allow(Signal).to receive(:trap) do |sig, &blk|
+        trapped[sig] = blk
+      end
+
+      server.send(:install_signal_handlers)
+
+      %w[INT TERM HUP].each { |s| expect(trapped).to have_key(s) }
+
+      trapped['INT'].call
+      trapped['TERM'].call
+      trapped['HUP'].call
+
+      signals = server.instance_variable_get(:@signals)
+      drained = [signals.pop, signals.pop, signals.pop]
+      expect(drained).to contain_exactly(:stop, :stop, :reload)
+    end
+  end
+
+  describe '#perform_reload' do
+    it 'reloads poller + HttpApp and logs reload.ok only when both succeed' do
+      poller = instance_double(CgminerMonitor::Poller, reload!: 3)
+      config = instance_double(CgminerMonitor::Config, miners_file: '/tmp/m.yml')
+      server = described_class.allocate
+      server.instance_variable_set(:@poller, poller)
+      server.instance_variable_set(:@config, config)
+
+      allow(CgminerMonitor::HttpApp).to receive(:reload_miners!).with('/tmp/m.yml').and_return(3)
+      allow(CgminerMonitor::Logger).to receive(:info)
+
+      server.send(:perform_reload)
+
+      expect(CgminerMonitor::Logger).to have_received(:info).with(event: 'reload.signal_received')
+      expect(CgminerMonitor::Logger).to have_received(:info).with(event: 'reload.ok', miners: 3)
+    end
+
+    it 'does not log reload.ok when poller reload fails' do
+      poller = instance_double(CgminerMonitor::Poller, reload!: nil)
+      config = instance_double(CgminerMonitor::Config, miners_file: '/tmp/m.yml')
+      server = described_class.allocate
+      server.instance_variable_set(:@poller, poller)
+      server.instance_variable_set(:@config, config)
+
+      allow(CgminerMonitor::HttpApp).to receive(:reload_miners!).and_return(3)
+      allow(CgminerMonitor::Logger).to receive(:info)
+
+      server.send(:perform_reload)
+
+      expect(CgminerMonitor::Logger).not_to have_received(:info).with(hash_including(event: 'reload.ok'))
+    end
+
+    it 'does not log reload.ok when HttpApp reload fails' do
+      poller = instance_double(CgminerMonitor::Poller, reload!: 3)
+      config = instance_double(CgminerMonitor::Config, miners_file: '/tmp/m.yml')
+      server = described_class.allocate
+      server.instance_variable_set(:@poller, poller)
+      server.instance_variable_set(:@config, config)
+
+      allow(CgminerMonitor::HttpApp).to receive(:reload_miners!).and_return(nil)
+      allow(CgminerMonitor::Logger).to receive(:info)
+
+      server.send(:perform_reload)
+
+      expect(CgminerMonitor::Logger).not_to have_received(:info).with(hash_including(event: 'reload.ok'))
+    end
+  end
+
+  describe '#write_pid_file / #unlink_pid_file' do
+    let(:pid_path) { File.join(Dir.mktmpdir, 'test.pid') }
+    let(:config)   { instance_double(CgminerMonitor::Config, pid_file: pid_path) }
+    let(:server) do
+      s = described_class.allocate
+      s.instance_variable_set(:@config, config)
+      s
+    end
+
+    after { FileUtils.rm_f(pid_path) }
+
+    it 'writes the current pid to the configured path' do
+      allow(CgminerMonitor::Logger).to receive(:info)
+      server.send(:write_pid_file)
+      expect(File.read(pid_path).strip).to eq(Process.pid.to_s)
+    end
+
+    it 'unlinks the pid file' do
+      File.write(pid_path, "#{Process.pid}\n")
+      server.send(:unlink_pid_file)
+      expect(File.exist?(pid_path)).to be(false)
+    end
+
+    it 'tolerates an already-deleted pid file on unlink' do
+      expect { server.send(:unlink_pid_file) }.not_to raise_error
+    end
+
+    it 'is a no-op when pid_file is nil' do
+      allow(config).to receive(:pid_file).and_return(nil)
+      expect { server.send(:write_pid_file) }.not_to raise_error
+      expect { server.send(:unlink_pid_file) }.not_to raise_error
+    end
+  end
+end

--- a/spec/cgminer_monitor/server_spec.rb
+++ b/spec/cgminer_monitor/server_spec.rb
@@ -55,14 +55,14 @@ RSpec.describe CgminerMonitor::Server do
       allow(server).to receive(:bootstrap_mongoid!)
       allow(server).to receive(:validate_startup!)
       allow(server).to receive(:install_signal_handlers)
-      allow(server).to receive(:reinstall_signal_handlers)
       # Prevent the poller + puma threads from actually starting.
       allow(server.poller).to receive(:run_until_stopped)
       allow(server.poller).to receive(:stop)
       fake_launcher = instance_double(Puma::Launcher, run: nil, stop: nil)
       allow(server).to receive(:build_puma_launcher).and_return(fake_launcher)
-      # Push a signal immediately so #run doesn't block.
-      server.instance_variable_get(:@stop).push('TEST')
+      # Push sentinels so #run doesn't block on @booted.pop or the signal dispatcher.
+      server.instance_variable_get(:@booted).push(true)
+      server.instance_variable_get(:@signals).push(:stop)
     end
 
     after do
@@ -79,8 +79,7 @@ RSpec.describe CgminerMonitor::Server do
   end
 
   describe 'signal handling' do
-    it 'installs TERM and INT signal handlers' do
-      # Capture the signals that get trapped
+    it 'installs TERM, INT, and HUP signal handlers' do
       trapped = []
       allow(Signal).to receive(:trap) do |sig, &_block|
         trapped << sig
@@ -88,7 +87,7 @@ RSpec.describe CgminerMonitor::Server do
 
       server.send(:install_signal_handlers)
 
-      expect(trapped).to contain_exactly('TERM', 'INT')
+      expect(trapped).to contain_exactly('TERM', 'INT', 'HUP')
     end
   end
 
@@ -121,15 +120,10 @@ RSpec.describe CgminerMonitor::Server do
   end
 
   describe 'graceful shutdown' do
-    it 'stops the poller and puma when signaled' do
-      stop_queue = server.instance_variable_get(:@stop)
-
-      # Simulate signal delivery
-      stop_queue << 'TERM'
-
-      # Verify the queue has the signal
-      signal = stop_queue.pop
-      expect(signal).to eq 'TERM'
+    it 'uses the @signals queue to deliver shutdown sentinels' do
+      signals = server.instance_variable_get(:@signals)
+      signals << :stop
+      expect(signals.pop).to eq(:stop)
     end
   end
 

--- a/spec/integration/cli_reload_spec.rb
+++ b/spec/integration/cli_reload_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'open3'
+require 'tmpdir'
+require 'fileutils'
+
+RSpec.describe 'bin/cgminer_monitor reload', type: :integration do
+  around do |example|
+    WebMock.allow_net_connect! if defined?(WebMock)
+    example.run
+  ensure
+    WebMock.disable_net_connect! if defined?(WebMock)
+  end
+
+  it 'exits non-zero with a helpful message when PID file is unset' do
+    dir         = Dir.mktmpdir
+    miners_path = File.join(dir, 'miners.yml')
+    File.write(miners_path, "- host: 127.0.0.1\n  port: 4028\n")
+    env = {
+      'CGMINER_MONITOR_MONGO_URL' => 'mongodb://127.0.0.1:27017/test_db',
+      'CGMINER_MONITOR_MINERS_FILE' => miners_path
+    }
+    _, err, status = Open3.capture3(env, 'bundle', 'exec', 'bin/cgminer_monitor', 'reload',
+                                    chdir: File.expand_path('../..', __dir__))
+    expect(status.exitstatus).not_to eq(0)
+    expect(err).to match(/CGMINER_MONITOR_PID_FILE/)
+  ensure
+    FileUtils.rm_rf(dir)
+  end
+end

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -113,4 +113,72 @@ RSpec.describe 'CLI integration', :integration do
       expect(status.exitstatus).not_to eq 0
     end
   end
+
+  # SIGHUP path: spawn a real cgminer_monitor, rewrite miners.yml,
+  # send SIGHUP, and assert reload.signal_received + reload.ok appear in
+  # captured stdout. The log-match is the regression guard against a
+  # future change that silently swallows SIGHUP — e.g., Puma reinstalling
+  # its own HUP trap (which calls stop()) between our install and the
+  # process boundary. Relies on Mongo at localhost:27017; skipped when
+  # Mongo isn't reachable.
+  describe 'reload via SIGHUP', :integration do
+    def wait_for_bind!(host, port, timeout: 15)
+      deadline = Time.now + timeout
+      until Time.now >= deadline
+        begin
+          TCPSocket.new(host, port).close
+          return
+        rescue Errno::ECONNREFUSED, Errno::EINVAL
+          Thread.pass
+        end
+      end
+      raise 'server did not bind within deadline'
+    end
+
+    it 'reloads miners on SIGHUP' do
+      dir = Dir.mktmpdir
+      sighup_miners = File.join(dir, 'miners.yml')
+      pid_path      = File.join(dir, 'cm-monitor.pid')
+      File.write(sighup_miners, "- host: 127.0.0.1\n  port: 4028\n")
+
+      port = 9293 # fixed port; avoids TIME_WAIT races from ephemeral port reuse
+
+      spawn_env = {
+        'CGMINER_MONITOR_MINERS_FILE' => sighup_miners,
+        'CGMINER_MONITOR_MONGO_URL' => env['CGMINER_MONITOR_MONGO_URL'],
+        'CGMINER_MONITOR_HTTP_PORT' => port.to_s,
+        'CGMINER_MONITOR_HTTP_HOST' => '127.0.0.1',
+        'CGMINER_MONITOR_SHUTDOWN_TIMEOUT' => '3',
+        'CGMINER_MONITOR_PID_FILE' => pid_path,
+        'CGMINER_MONITOR_LOG_FORMAT' => 'json'
+      }
+
+      log_r, log_w = IO.pipe
+      pid = spawn(spawn_env, 'bundle', 'exec', bin_path, 'run',
+                  out: log_w, err: log_w)
+      log_w.close
+
+      begin
+        wait_for_bind!('127.0.0.1', port)
+
+        deadline = Time.now + 5
+        sleep 0.05 until File.exist?(pid_path) || Time.now > deadline
+        expect(File.read(pid_path).strip).to eq(pid.to_s)
+
+        File.write(sighup_miners,
+                   "- host: 127.0.0.1\n  port: 4028\n" \
+                   "- host: 127.0.0.1\n  port: 4029\n")
+        Process.kill('HUP', pid)
+        sleep 0.5 # let the dispatcher process the signal
+      ensure
+        Process.kill('TERM', pid) rescue nil # rubocop:disable Style/RescueModifier
+        Process.wait(pid)
+        logged = log_r.read
+        log_r.close
+        expect(logged).to match(/reload\.signal_received/)
+        expect(logged).to match(/reload\.ok/)
+        FileUtils.rm_rf(dir)
+      end
+    end
+  end
 end

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -158,6 +158,7 @@ RSpec.describe 'CLI integration', :integration do
                   out: log_w, err: log_w)
       log_w.close
 
+      captured = +''
       begin
         wait_for_bind!('127.0.0.1', port)
 
@@ -169,14 +170,28 @@ RSpec.describe 'CLI integration', :integration do
                    "- host: 127.0.0.1\n  port: 4028\n" \
                    "- host: 127.0.0.1\n  port: 4029\n")
         Process.kill('HUP', pid)
-        sleep 0.5 # let the dispatcher process the signal
+
+        # Poll the log pipe for reload.ok with a deadline instead of
+        # sleep(0.5). The stdout fd is non-blocking-read via select;
+        # this eliminates the "under CI load the dispatcher hasn't
+        # processed the signal yet" flake and races.
+        deadline = Time.now + 5
+        until Time.now > deadline
+          captured << log_r.read_nonblock(65_536) if log_r.wait_readable(0.1)
+          break if captured.include?('reload.ok')
+        end
+        expect(captured).to include('reload.signal_received')
+        expect(captured).to include('reload.ok')
       ensure
         Process.kill('TERM', pid) rescue nil # rubocop:disable Style/RescueModifier
         Process.wait(pid)
-        logged = log_r.read
+        # Drain any trailing output the server emitted during shutdown.
+        begin
+          captured << log_r.read
+        rescue IOError
+          # pipe already closed — fine
+        end
         log_r.close
-        expect(logged).to match(/reload\.signal_received/)
-        expect(logged).to match(/reload\.ok/)
         FileUtils.rm_rf(dir)
       end
     end


### PR DESCRIPTION
## Summary

Mirror of `cgminer_manager` PR #17 on the monitor side. Operators can add, remove, or re-label a miner in `config/miners.yml` and have it picked up without restarting the monitor.

- **SIGHUP handler** (`lib/cgminer_monitor/server.rb`) — `@stop` queue renamed to `@signals` carrying symbolic messages. `:stop` (INT/TERM) drops through the existing shutdown path; `:reload` triggers both `@poller.reload!` and `HttpApp.reload_miners!`.
- **Correctness fix along the way** — replaced `sleep(0.05)` with `launcher.events.on_booted` → `@booted` queue for the post-Puma-boot trap reinstall. Puma 8.0.0's `setup_signals` installs its own SIGHUP handler that calls `stop()` when `stdout_redirect` is unset; the racy sleep could leave Puma's trap in place, eating reload signals. `on_booted` is deterministic.
- **Atomic swap** — `HttpApp.reload_miners!(path)` replaces `settings.configured_miners` with a fresh frozen tuple Array; `Poller#reload!` builds a new `CgminerApiClient::MinerPool` and atomically swaps `@miner_pool`. `poll_once` now captures the pool once at the top of the tick so a mid-poll swap can't mix old miner_ids with new pool query results.
- **Failure posture** — parse/IO failures log `event=reload.failed` and keep the old list (both sides of the swap independently). `perform_reload` only logs `reload.ok` when both Poller and HttpApp reloads succeed.
- **PID file lifecycle** — `CGMINER_MONITOR_PID_FILE` (optional), written after `on_booted`, unlinked in `run`'s `ensure`.
- **`reload` CLI verb** — dry-run-parses miners.yml before signaling (exit 78 on malformed YAML, matching existing ConfigError posture from `run`/`migrate`).
- **`doctor` PID-file posture** — three-state report: `not configured` / `OK (pid N)` / `STALE` / `MISSING`.
- **Integration test** — spawns real `bin/cgminer_monitor run`, rewrites miners.yml, sends SIGHUP, asserts `reload.signal_received` + `reload.ok` appear in captured stdout.

## Test plan

- [x] `bundle exec rake` passes (140 examples, 0 failures, rubocop clean)
- [x] Integration test sends real SIGHUP to a spawned server and observes reload
- [x] Manual smoke: `reload` verb exits 78 on malformed miners.yml *before* signaling; SIGHUP with malformed YAML logs `reload.failed` and keeps the old list
- [ ] After merge: bump to v0.2.0, update CHANGELOG release date on master, tag + push — multi-arch container image publishes automatically

## Risks

- Correctness argument rests on MRI GVL. No TruffleRuby/JRuby target today; worth re-examining if that ever changes.
- `@stop` → `@signals` rename + `sleep(0.05)` → `on_booted` change are both contained to private `Server` state; no external callers.
- The `on_booted` change also slightly improves the existing SIGTERM shutdown path — the SIGTERM full-boot integration test still passes.