### PR TITLE
Add Dependabot config for Bundler, GitHub Actions, and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    versioning-strategy: lockfile-only
+    labels:
+      - dependencies
+      - ruby
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: docker
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Dependabot config** (`.github/dependabot.yml`). Weekly bump PRs
+  for Bundler, GitHub Actions, and Docker `FROM` base images, with
+  `open-pull-requests-limit: 3` per ecosystem. `versioning-strategy:
+  lockfile-only` on bundler keeps gemspec `~>` bounds stable — the
+  lockfile moves forward automatically, but a human widens bounds
+  when intent is to adopt a new line. PRs target `develop`.
+
 ## [1.1.0] — 2026-04-22
 
 ### Added


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` tracking Bundler, GitHub Actions, and Docker weekly.
- `open-pull-requests-limit: 3` per ecosystem; PRs target `develop`.
- `versioning-strategy: lockfile-only` on bundler — gemspec `~>` bounds stay stable, lockfile moves automatically.
- CHANGELOG entry under `[Unreleased]`.

## Test plan
- [ ] CI green on the feature branch (Ruby code unchanged).
- [ ] After merge: Insights → Dependency graph → Dependabot lists `bundler`, `github-actions`, and `docker` as tracked ecosystems, no red parse error.
- [ ] `bundler` entry shows `Gemfile.lock` detected.
- [ ] `docker` entry shows `Dockerfile` detected.
- [ ] Next weekly run opens bump PRs (if any are available) against `develop`, labeled `dependencies`.