### PR TITLE
Add bundle-audit to CI for Gemfile.lock CVE gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,21 @@ jobs:
       - name: Run RuboCop
         run: bundle exec rubocop
 
+  audit:
+    name: bundle-audit
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Run bundle-audit
+        run: bundle exec bundle-audit check --update
+
   test:
     name: Ruby ${{ matrix.ruby }} / Mongo ${{ matrix.mongo }}
     runs-on: ubuntu-24.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`bundle-audit` in CI** (`.github/workflows/ci.yml`). New `audit`
+  job runs `bundle exec bundle-audit check --update` on every push
+  and PR, gating merges on known CVEs in `Gemfile.lock`. Advisory
+  DB is refreshed on each run. Also available locally as
+  `bundle exec rake audit`.
 - **Dependabot config** (`.github/dependabot.yml`). Weekly bump PRs
   for Bundler, GitHub Actions, and Docker `FROM` base images, with
   `open-pull-requests-limit: 3` per ecosystem. `versioning-strategy:

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem 'ostruct' if RUBY_VERSION >= '3.5'
 
 group :development do
+  gem 'bundler-audit', '>= 0.9'
   gem 'rack-test',     '>= 2.1'
   gem 'rake',          '>= 13.2'
   gem 'rspec',         '>= 3.13'

--- a/Rakefile
+++ b/Rakefile
@@ -12,3 +12,8 @@ task default: %i[spec rubocop]
 
 desc 'Alias for spec'
 task test: :spec
+
+desc 'Check Gemfile.lock against the ruby-advisory-db for known CVEs'
+task :audit do
+  sh 'bundle exec bundle-audit check --update'
+end


### PR DESCRIPTION
## Summary
- Adds `bundler-audit` to the `group :development` dev gems.
- New `audit` job in `.github/workflows/ci.yml` runs `bundle exec bundle-audit check --update` on every push and PR, gating merges on any known CVE in `Gemfile.lock`.
- `rake audit` task available locally.
- CHANGELOG entry under `[Unreleased]`.

Complements the Dependabot config landed in PR #6.

## Test plan
- [x] `bundle exec rake audit` passes locally (1078 advisories; no vulnerabilities found).
- [x] Non-integration rspec + rubocop still green.
- [x] CI `audit` job turns green on the PR.