### PR TITLE
docs: canonical structured-log schema; flatten server.start shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and a reverse-proxy + TLS nginx snippet. Posture itself is
   unchanged (monitor remains auth-free by design); only the
   documentation is clearer.
+- **`server.start` log entry** now emits flat scalar keys (`pid`,
+  `bind`, `port`, `log_format`, `log_level`, `mongo_url`) rather
+  than a nested `config:` hash. Matches `cgminer_manager`'s
+  `server.start` shape and the style of every other structured-log
+  emit site. Log consumers that queried `config.mongo_url` need to
+  query `mongo_url` directly; `config.*` nested access no longer
+  resolves. `mongo_url` remains credential-redacted.
+
+### Added
+- **`docs/log_schema.md`** — canonical structured-log schema for
+  the three sibling gems, covering reserved keys, standard-key
+  types, namespace reservations (which repo owns `poll.*`,
+  `admin.*`, `rate_limit.*`, etc.), a full per-event catalog with
+  required and optional keys, evolution rules, and grep recipes
+  for log consumers. `cgminer_manager` and `cgminer_api_client`
+  link here rather than duplicate the contract.
 
 ## [1.1.0] — 2026-04-22
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -84,7 +84,7 @@ Public surface:
 - `Config.from_env(env = ENV)` — build + validate in one call. Raises `ConfigError` on bad values.
 - `Config.current` — memoized `from_env` result for code paths that want a global handle (primarily `HttpApp`). `Config.reset!` clears the memo (tests only).
 - `#validate!` — runs sanity checks: `interval > 0`, `log_format ∈ {json, text}`, `miners_file` exists, `log_level ∈ {debug, info, warn, error}`.
-- `#public_attrs` — `to_h` with the mongo URL redacted (`mongodb://user:pass@host` → `mongodb://[REDACTED]@host`). Used for logging and `doctor` output.
+- `#public_attrs` — `to_h` with the mongo URL redacted (`mongodb://user:pass@host` → `mongodb://[REDACTED]@host`). Used by `doctor` output and supplies the redacted `mongo_url` value for the `server.start` log entry.
 
 Any constructor field that fails parsing surfaces as a `ConfigError` at boot time, which the CLI translates into exit `78` (`EX_CONFIG`).
 

--- a/docs/data_models.md
+++ b/docs/data_models.md
@@ -142,7 +142,7 @@ classDiagram
 - `log_level ∈ {"debug", "info", "warn", "error"}`
 - `File.exist?(miners_file)`
 
-**`public_attrs`** returns `to_h` with `mongo_url` redacted (`mongodb://user:pass@host` → `mongodb://[REDACTED]@host`). Used by the log startup line and by `cgminer_monitor doctor`.
+**`public_attrs`** returns `to_h` with `mongo_url` redacted (`mongodb://user:pass@host` → `mongodb://[REDACTED]@host`). Used by `cgminer_monitor doctor`; also supplies the redacted `mongo_url` value emitted in the `server.start` structured-log entry.
 
 **Immutable by design.** Config cannot be mutated at runtime. A config change requires a restart. Justified because the process model is supervisor-driven and a restart is cheap.
 

--- a/docs/log_schema.md
+++ b/docs/log_schema.md
@@ -1,0 +1,234 @@
+# Structured log schema
+
+Canonical contract for the structured logs emitted by the three sibling gems:
+
+- `cgminer_monitor` — owns the poll loop and the time-series HTTP API.
+- `cgminer_manager` — owns the admin/rate-limit/UI surface and client calls to monitor.
+- `cgminer_api_client` — **silent by design.** Raises on failure, returns result objects on success. No `Logger` module, no log call sites. Callers own the emission. See `cgminer_api_client/docs/logging.md`.
+
+Log consumers (Loki, Datadog, Vector, grep) can treat this document as the source of truth for key names, types, and event namespaces. All three repos link here rather than duplicate the contract.
+
+## Scope + non-goals
+
+- **Covered:** every `Logger.{debug,info,warn,error}(...)` call site in `cgminer_monitor/lib/` and `cgminer_manager/lib/`.
+- **Not covered:** Puma's own startup/shutdown logs, Rack-level access logs (those flow through Puma's stdout independently), MongoDB client logs, Mongoid query logs. These use their own formats and are out of contract.
+- **Not covered:** ad-hoc `puts` / `STDERR.puts` in CLI binstubs for human-readable output (`doctor`, `reload`, `migrate`). CLI output is for humans; structured logs are for machines.
+
+## Transport
+
+- Single-line JSON per event on stdout, by default (`Logger.format = 'json'`).
+- Humans set `Logger.format = 'text'` to get `ts LEVEL event k=v k=v` for local debugging; the text form is not a parseable contract.
+- `Logger.level` filters by the ordered set `debug < info < warn < error`. Default: `info`.
+
+## Reserved always-present keys
+
+Every JSON object emitted by the house `Logger` module begins with these three keys before any caller-supplied fields:
+
+| Key     | Type   | Format                                        | Notes                                                  |
+|---------|--------|-----------------------------------------------|--------------------------------------------------------|
+| `ts`    | string | ISO-8601 UTC with millisecond precision       | `2026-04-23T18:03:02.697Z`                             |
+| `level` | string | one of `debug`, `info`, `warn`, `error`       | lowercase; no `trace`/`fatal`                          |
+| `event` | string | dotted lowercase `<namespace>.<action>`       | always present; grep-anchor                            |
+
+The `event` value is the single most important key — every downstream consumer should route/filter on it first.
+
+## Standard keys
+
+Keys that appear across multiple events are named consistently. When you add a new event, prefer reusing a standard key over minting a new one.
+
+| Key               | Type             | Example                                     | Meaning / notes |
+|-------------------|------------------|---------------------------------------------|-----------------|
+| `pid`             | integer          | `42315`                                     | `Process.pid` of the emitter |
+| `bind`            | string           | `"127.0.0.1"`                               | HTTP bind host |
+| `port`            | integer          | `9292`                                      | HTTP listen port |
+| `path`            | string           | `"/manager/admin/version"`                  | Rack `request.path`; also used for pid-file paths on `server.pid_file_written` |
+| `method`          | string           | `"POST"`                                    | HTTP verb, uppercase |
+| `status`          | integer          | `200`                                       | HTTP response code |
+| `url`             | string           | `"/v2/miners"`                              | outbound URL (e.g. manager → monitor) |
+| `duration_ms`     | integer          | `1234`                                      | milliseconds, rounded. **Standardized name** — do not use `elapsed_ms`, `render_ms`, `took_ms`, or `latency_ms` |
+| `error`           | string           | `"Mongo::Error::OperationFailure"`          | exception class name via `e.class.to_s`. Never an exception object |
+| `message`         | string           | `"Connection refused"`                      | `e.message` |
+| `backtrace`       | array\<string\>  | `["file.rb:42 in …", …]`                    | first 10 frames by convention (`e.backtrace&.first(10)`) |
+| `remote_ip`       | string           | `"192.0.2.10"`                              | client IP (post-trust-walk for proxied requests) |
+| `user_agent`      | string           | `"curl/8.9.1"`                              | raw `HTTP_USER_AGENT` |
+| `user`            | string or `nil`  | `"admin"`                                   | admin-surface Basic-Auth username; `nil` when unauthenticated |
+| `session_id_hash` | string           | `"a3f1e2d4b6c8"`                            | first 12 hex chars of `SHA256(session_id)`; never the raw session id |
+| `request_id`      | string           | UUID v4                                     | threads entry/exit events for a single admin POST |
+| `command`         | string           | `"version"`, `"addpool"`                    | cgminer verb or admin command name |
+| `scope`           | string           | `"all"`, `"rig-01"`, `"pool-0"`             | admin-command target selector |
+| `args`            | hash             | `{ pool_id: "0" }`                          | optional extra context on admin events; shape is per-command |
+| `reason`          | string           | `"missing_credentials"`                     | short enum-like string on auth-failure events |
+| `retry_after`     | integer          | `42`                                        | seconds; paired with 429 responses |
+| `miner`           | string           | `"10.0.0.5:4028"`                           | scalar rig identifier — `"host:port"` |
+| `miners`          | integer          | `3`                                         | count of miners (or an array where the emit site documents it). Never a single rig |
+| `log_format`      | string           | `"json"` or `"text"`                        | effective formatter — `server.start` only |
+| `log_level`       | string           | `"info"`                                    | effective level threshold — `server.start` only |
+| `mongo_url`       | string           | `"mongodb://[REDACTED]@db:27017/monitor"`   | always credential-redacted; `server.start` only |
+| `ok_count`        | integer          | `2`                                         | admin-command scope hits that succeeded |
+| `failed_count`    | integer          | `1`                                         | admin-command scope hits that failed |
+| `samples_written` | integer          | `48`                                        | Mongo write count on a poll tick |
+| `snapshots_upserted` | integer       | `12`                                        | Mongo upsert count on a poll tick |
+| `polls_ok`        | integer          | `12`                                        | miners polled successfully on a tick |
+| `polls_failed`    | integer          | `0`                                         | miners that errored on a tick |
+| `poller_ok`       | boolean          | `true`                                      | reload-partial diagnostic |
+| `http_app_ok`     | boolean          | `false`                                     | reload-partial diagnostic |
+
+**Convention:** scalar `miner:` for a rig id (string `"host:port"`); plural `miners:` for a count (integer). Reserved — don't reintroduce `miner_id:` or use `miner:` for an array.
+
+## Namespace reservations
+
+Namespaces partition the event space; each prefix is owned by exactly one repo except where noted.
+
+**cgminer_monitor only:**
+
+- `poll.*` — the monitoring poll loop (`poll.complete`, `poll.miner_failed`, `poll.unexpected_error`).
+- `mongo.*` — Mongo write failures from the poll loop (`mongo.write_failed`).
+- `migrate.*` — one-shot index/migration operations (`migrate.complete`).
+- `startup.*` — pre-Puma startup validation (`startup.mongo_unreachable`).
+- `healthz.*` — readiness-probe results (`healthz.mongo_unreachable`).
+
+**cgminer_manager only:**
+
+- `admin.*` — admin surface (`admin.command`, `admin.result`, `admin.auth_failed`, `admin.auth_misconfigured`).
+- `rate_limit.*` — rate-limiter (`rate_limit.exceeded`).
+- `monitor.*` — **manager's client calls to the monitor service** (`monitor.call`, `monitor.call.failed`). This is intentional: the prefix names the *dependency*, not the emitter.
+- `http.*` — Rack request-level events (`http.request`, `http.500`, `http.unhandled_error`). Manager emits `http.request` + `http.500`; monitor emits `http.unhandled_error`. Technically shared via `http.unhandled_error`; see below.
+
+**Shared (emitted by both):**
+
+- `server.*` — process lifecycle (`server.start`, `server.stopping`, `server.stopped`, `server.crash`, `server.pid_file_written`).
+- `reload.*` — SIGHUP hot-reload (`reload.signal_received`, `reload.ok`, `reload.failed`). `reload.partial` is monitor-only within this namespace — emitted from `lib/cgminer_monitor/server.rb` when Poller + HttpApp reload outcomes diverge; no manager equivalent because manager has no Poller.
+- `puma.*` — Puma-thread crashes (`puma.crash`).
+- `http.unhandled_error` — emitted by both repos for uncaught exceptions below the Sinatra error handler.
+
+## Event catalog
+
+Organized alphabetically within namespace. "Required" columns list keys beyond the reserved triple (`ts`, `level`, `event`).
+
+### `admin.*` (cgminer_manager)
+
+| Event | Level | Emitter | Required keys | Optional |
+|-------|-------|---------|---------------|----------|
+| `admin.auth_failed` | warn | `AdminAuth` | `reason`, `path`, `remote_ip`, `user_agent` | |
+| `admin.auth_misconfigured` | warn | `AdminAuth` | `path`, `remote_ip`, `user_agent` | |
+| `admin.command` | info | `HttpApp` via `AdminLogging.command_log_entry` | `request_id`, `user`, `remote_ip`, `user_agent`, `session_id_hash`, `command`, `scope` | `args` and other per-command extras |
+| `admin.result` | info | `HttpApp` via `AdminLogging.result_log_entry` | `request_id`, `command`, `scope`, `ok_count`, `failed_count`, `duration_ms` | |
+
+### `healthz.*` (cgminer_monitor)
+
+| Event | Level | Emitter | Required keys | Optional |
+|-------|-------|---------|---------------|----------|
+| `healthz.mongo_unreachable` | warn | `HttpApp` `/v2/healthz` | `error`, `message` | |
+
+### `http.*` (both)
+
+| Event | Level | Emitter | Required keys | Optional |
+|-------|-------|---------|---------------|----------|
+| `http.request` | info | cgminer_manager `HttpApp` (after-filter) | `path`, `method`, `status`, `duration_ms` | |
+| `http.500` | error | cgminer_manager `HttpApp` | `error`, `message`, `backtrace` | |
+| `http.unhandled_error` | error | cgminer_monitor `HttpApp` | `error`, `message`, `backtrace` | |
+
+### `migrate.*` (cgminer_monitor)
+
+| Event | Level | Emitter | Required keys | Optional |
+|-------|-------|---------|---------------|----------|
+| `migrate.complete` | info | `bin/cgminer_monitor migrate` | `message` | |
+
+### `monitor.*` (cgminer_manager)
+
+| Event | Level | Emitter | Required keys | Optional |
+|-------|-------|---------|---------------|----------|
+| `monitor.call` | info | `MonitorClient` | `url`, `status`, `duration_ms` | |
+| `monitor.call.failed` | warn | `MonitorClient` | `url`, `error`, `message` | |
+
+### `mongo.*` (cgminer_monitor)
+
+| Event | Level | Emitter | Required keys | Optional |
+|-------|-------|---------|---------------|----------|
+| `mongo.write_failed` | error | `Poller` | `error`, `message` | |
+
+### `poll.*` (cgminer_monitor)
+
+| Event | Level | Emitter | Required keys | Optional |
+|-------|-------|---------|---------------|----------|
+| `poll.complete` | info | `Poller` | `samples_written`, `snapshots_upserted`, `polls_ok`, `polls_failed` | |
+| `poll.miner_failed` | warn | `Poller` | `miner`, `command`, `error` | |
+| `poll.unexpected_error` | error | `Poller` | `error`, `message`, `backtrace` | |
+
+### `puma.*` (both)
+
+| Event | Level | Emitter | Required keys | Optional |
+|-------|-------|---------|---------------|----------|
+| `puma.crash` | error | both `Server#run` rescues | `error`, `message`, `backtrace` | |
+
+### `rate_limit.*` (cgminer_manager)
+
+| Event | Level | Emitter | Required keys | Optional |
+|-------|-------|---------|---------------|----------|
+| `rate_limit.exceeded` | warn | `RateLimiter` | `remote_ip`, `path`, `retry_after` | |
+
+### `reload.*` (both; `reload.partial` monitor-only)
+
+| Event | Level | Emitter | Required keys | Optional |
+|-------|-------|---------|---------------|----------|
+| `reload.signal_received` | info | both `Server` SIGHUP handlers | — | |
+| `reload.ok` | info | both | `miners` | |
+| `reload.failed` | warn | both | `error`, `message` | |
+| `reload.partial` | error | cgminer_monitor `Server` only | `poller_ok`, `http_app_ok` | |
+
+### `server.*` (both)
+
+| Event | Level | Emitter | Required keys | Optional |
+|-------|-------|---------|---------------|----------|
+| `server.start` | info | both `Server#run` | `pid`, `bind`, `port`, `log_format`, `log_level` | `mongo_url` (monitor only) |
+| `server.stopping` | info | both | — | |
+| `server.stopped` | info | both | — | |
+| `server.crash` | error | cgminer_monitor `Server` | `error`, `message`, `backtrace` | |
+| `server.pid_file_written` | info | both | `path` | |
+
+### `startup.*` (cgminer_monitor)
+
+| Event | Level | Emitter | Required keys | Optional |
+|-------|-------|---------|---------------|----------|
+| `startup.mongo_unreachable` | error | `Server` | `error`, `message` | |
+
+## Evolution rules
+
+This contract is pre-1.0 and not bound by SemVer; consumers should expect it to grow. Rules for additions and changes:
+
+1. **Adding a new event** — pick an existing namespace or reserve a new one in this document (with repo ownership) before the first emit. Use existing standard keys where possible; new keys require a row in the standard-keys table above.
+2. **Renaming an event or a key** — breaking change for log consumers. Land the rename with a `### Changed` CHANGELOG entry in the owning repo that explicitly names the old and new identifiers. Do not ship silent renames.
+3. **Namespace ownership moves** — if a shared event becomes single-repo, or vice versa, update the namespace reservations section. The reverse (moving a single-repo namespace to shared) requires mirroring the event catalog entry across both repos' emit sites.
+4. **Deprecation** — we don't emit both old and new names during a transition. Logs are low-cost to regenerate; dashboards are cheap to update. Pay the one-shot cost rather than carrying forever.
+5. **Reserved words** — `ts`, `level`, `event` are injected by the `Logger` module; callers cannot override them. Adding another auto-injected key would affect every event in the catalog; don't.
+
+## Grep recipes
+
+Starting points for log consumers. Pipe stdout through `jq -c` first to get one JSON object per line.
+
+Filter by namespace:
+```
+jq -c 'select(.event | startswith("admin."))' app.log
+```
+
+Filter by event + error class (triage a regression):
+```
+jq -c 'select(.event == "poll.miner_failed" and .error == "CgminerApiClient::ConnectionError")' app.log
+```
+
+Trace a single admin POST end-to-end:
+```
+jq -c 'select(.request_id == "a1b2c3d4-0000-0000-0000-000000000000")' app.log
+```
+
+Aggregate duration_ms p95 on a single event (requires `jq` + `awk` or a proper aggregator):
+```
+jq -c 'select(.event == "http.request") | .duration_ms' app.log \
+  | sort -n | awk '{a[NR]=$1} END{print a[int(NR*0.95)]}'
+```
+
+## Out-of-contract
+
+- Exception objects are never serialized directly — always `e.class.to_s` → `error` and `e.message` → `message`.
+- Log values don't include the raw session id or the raw Basic-Auth credential; admin events carry `session_id_hash` + `user` (username) instead.
+- `mongo_url` is always credential-redacted at the emit site; there is no code path that logs the raw connection string.

--- a/lib/cgminer_monitor/server.rb
+++ b/lib/cgminer_monitor/server.rb
@@ -29,8 +29,13 @@ module CgminerMonitor
       HttpApp.set :started_at,         Time.now.utc
       HttpApp.set :configured_miners,  HttpApp.parse_miners_file(@config.miners_file)
 
-      Logger.info(event: 'server.start', pid: Process.pid,
-                  config: @config.public_attrs)
+      Logger.info(event: 'server.start',
+                  pid: Process.pid,
+                  bind: @config.http_host,
+                  port: @config.http_port,
+                  log_format: @config.log_format,
+                  log_level: @config.log_level,
+                  mongo_url: @config.public_attrs[:mongo_url])
 
       poller_thread = Thread.new { @poller.run_until_stopped(@signals) }
       puma_launcher = build_puma_launcher

--- a/spec/cgminer_monitor/server_spec.rb
+++ b/spec/cgminer_monitor/server_spec.rb
@@ -78,6 +78,50 @@ RSpec.describe CgminerMonitor::Server do
     end
   end
 
+  describe 'server.start log shape' do
+    # Pins the scalar-key contract. A regression that wrapped the config
+    # back into a nested `config:` hash (or dropped a scalar the schema
+    # doc lists as emitted) would break log consumers that grep for
+    # top-level `bind`/`port`/`mongo_url` keys.
+    before do
+      allow(server).to receive(:configure_mongoid!)
+      allow(server).to receive(:bootstrap_mongoid!)
+      allow(server).to receive(:validate_startup!)
+      allow(server).to receive(:install_signal_handlers)
+      allow(server.poller).to receive(:run_until_stopped)
+      allow(server.poller).to receive(:stop)
+      fake_launcher = instance_double(Puma::Launcher, run: nil, stop: nil)
+      allow(server).to receive(:build_puma_launcher).and_return(fake_launcher)
+      server.instance_variable_get(:@booted).push(true)
+      server.instance_variable_get(:@signals).push(:stop)
+    end
+
+    after do
+      CgminerMonitor::HttpApp.configure_for_test!(miners: nil, poller: nil, started_at: nil)
+    end
+
+    it 'emits flat scalar keys (pid, bind, port, log_format, log_level, mongo_url) — no nested config hash' do
+      captured = nil
+      allow(CgminerMonitor::Logger).to receive(:info) do |fields|
+        captured = fields if fields[:event] == 'server.start'
+      end
+
+      server.run
+
+      expect(captured).not_to be_nil
+      expect(captured).to include(
+        event: 'server.start',
+        pid: Process.pid,
+        bind: config.http_host,
+        port: config.http_port,
+        log_format: config.log_format,
+        log_level: config.log_level
+      )
+      expect(captured[:mongo_url]).to match(%r{\Amongodb://})
+      expect(captured).not_to have_key(:config)
+    end
+  end
+
   describe 'signal handling' do
     it 'installs TERM, INT, and HUP signal handlers' do
       trapped = []


### PR DESCRIPTION
## Summary

- Adds `docs/log_schema.md` as the canonical structured-log contract across the three sibling gems (monitor, manager, api_client). Covers reserved always-present keys (`ts`, `level`, `event`), a standard-keys table with types and examples, namespace reservations per repo, a full per-event catalog with required/optional keys, evolution rules, and grep recipes.
- Flattens the `server.start` log entry from a nested `config: { … }` hash to flat scalar keys (`pid`, `bind`, `port`, `log_format`, `log_level`, `mongo_url`), matching cgminer_manager's shape and the style of every other structured-log emit site in the repo.
- `mongo_url` stays credential-redacted via the existing `Config#public_attrs` redaction path — no new public API on `Config`.
- `docs/components.md` + `docs/data_models.md` prose updated to reflect the narrower `public_attrs` usage (now only `doctor` + supplying `mongo_url` to `server.start`).

## Scope

Commit 1 (refactor): `lib/cgminer_monitor/server.rb`, `spec/cgminer_monitor/server_spec.rb`, `docs/components.md`, `docs/data_models.md`.
Commit 2 (docs): `docs/log_schema.md`, `CHANGELOG.md`.

Companion PRs in `cgminer_manager` and `cgminer_api_client` add short `docs/logging.md` stubs linking here, plus — in manager — a log-key consistency pass (`elapsed_ms`/`render_ms` → `duration_ms`).

## Test plan

- [x] `bundle exec rake` — 147 examples, 0 failures (new server_spec assertion pins the scalar shape); rubocop clean
- [x] New `server_spec` assertion regresses loudly if a future change reintroduces the nested `config:` key or drops a documented scalar
- [ ] Eyeball the rendered `docs/log_schema.md` on the GitHub PR diff view — tables render, code fences render