### PR TITLE
docs(openapi): envelope schemas for snapshot + graph endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **OpenAPI envelope schemas** for the four miner-snapshot endpoints
+  (`/v2/miners/{miner}/{summary,stats,devices,pools}`) and the three
+  graph-data endpoints (`/v2/graph_data/{hashrate,temperature,availability}`).
+  Previously these 200 responses had `description:` only with no
+  `content:` block; the seven endpoints now reference one of two
+  reusable `components.schemas` (`SnapshotEnvelope` with `{ok, response,
+  error}`; `GraphDataEnvelope` with `{fields, data}`). The inner
+  `response:` on snapshot endpoints stays declared open
+  (`additionalProperties: true`) — cgminer-firmware payload drift is
+  not part of this envelope contract. Bumps OpenAPI `info.version`
+  `"2.0.0"` → `"2.1.0"` (additive, non-breaking). New
+  `spec/openapi_schema_spec.rb` pins the `$ref` wiring so a future
+  refactor that silently drops a reference fails loudly.
 - **`bundle-audit` in CI** (`.github/workflows/ci.yml`). New `audit`
   job runs `bundle exec bundle-audit check --update` on every push
   and PR, gating merges on known CVEs in `Gemfile.lock`. Advisory

--- a/lib/cgminer_monitor/openapi.yml
+++ b/lib/cgminer_monitor/openapi.yml
@@ -1,7 +1,7 @@
 openapi: "3.1.0"
 info:
   title: cgminer_monitor API
-  version: "2.0.0"
+  version: "2.1.0"
   description: |
     Periodically polls cgminer instances and exposes their state via HTTP.
   license:
@@ -82,6 +82,10 @@ paths:
       responses:
         "200":
           description: Device snapshot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SnapshotEnvelope"
         "404":
           description: Unknown miner
 
@@ -97,6 +101,10 @@ paths:
       responses:
         "200":
           description: Pool snapshot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SnapshotEnvelope"
         "404":
           description: Unknown miner
 
@@ -112,6 +120,10 @@ paths:
       responses:
         "200":
           description: Summary snapshot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SnapshotEnvelope"
         "404":
           description: Unknown miner
 
@@ -127,6 +139,10 @@ paths:
       responses:
         "200":
           description: Stats snapshot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SnapshotEnvelope"
         "404":
           description: Unknown miner
 
@@ -151,6 +167,10 @@ paths:
       responses:
         "200":
           description: Hashrate data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GraphDataEnvelope"
         "400":
           description: Invalid parameters
 
@@ -174,6 +194,10 @@ paths:
       responses:
         "200":
           description: Temperature data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GraphDataEnvelope"
         "400":
           description: Invalid parameters
 
@@ -197,6 +221,10 @@ paths:
       responses:
         "200":
           description: Availability data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GraphDataEnvelope"
         "400":
           description: Invalid parameters
 
@@ -215,3 +243,49 @@ paths:
       responses:
         "200":
           description: HTML documentation page
+
+components:
+  schemas:
+    SnapshotEnvelope:
+      type: object
+      required: [ok]
+      properties:
+        ok: { type: boolean }
+        response:
+          type: [object, "null"]
+          additionalProperties: true
+          description: |
+            Raw cgminer JSON payload for the requested command. The inner
+            shape depends on the cgminer command (SUMMARY, DEVS, POOLS,
+            STATS) and varies across firmware; intentionally declared
+            open so firmware variation doesn't invalidate the envelope
+            contract. Consumers should navigate it defensively.
+        error: { type: [string, "null"] }
+      description: |
+        Envelope for /v2/miners/{miner}/{summary,stats,devices,pools}.
+        A successful snapshot has `ok: true` with `response:` populated
+        and `error: null`. A failed fetch has `ok: false`, `error:`
+        populated with a short message, and `response:` typically null.
+
+    GraphDataEnvelope:
+      type: object
+      required: [fields, data]
+      properties:
+        fields:
+          type: array
+          items: { type: string }
+          description: |
+            Ordered list of column names for the rows in `data`. Callers
+            index into each row by matching on the field name rather
+            than by positional order, so additive column changes are
+            non-breaking.
+        data:
+          type: array
+          items:
+            type: array
+          description: |
+            Array of rows. Each row is a same-length array of values,
+            positionally aligned with `fields`. Value types vary per
+            column (timestamp, number, string) and are not pinned here.
+      description: |
+        Envelope for /v2/graph_data/{hashrate,temperature,availability}.

--- a/spec/openapi_schema_spec.rb
+++ b/spec/openapi_schema_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+# Tightness assertions on the envelope-schema wiring added in 2.1.0.
+# The sibling openapi_consistency_spec covers path parity (every route
+# documented; no phantom routes). This spec covers the response-body
+# shape: the seven endpoints that declared no schema before 2.1.0 now
+# each resolve a $ref to one of the two reusable envelope schemas.
+#
+# Regression target: a future edit that silently drops a $ref — or
+# renames SnapshotEnvelope / GraphDataEnvelope — should fail here
+# before it ships.
+RSpec.describe 'OpenAPI envelope schemas' do
+  snapshot_paths = %w[
+    /v2/miners/{miner}/summary
+    /v2/miners/{miner}/stats
+    /v2/miners/{miner}/devices
+    /v2/miners/{miner}/pools
+  ].freeze
+
+  graph_paths = %w[
+    /v2/graph_data/hashrate
+    /v2/graph_data/temperature
+    /v2/graph_data/availability
+  ].freeze
+
+  let(:openapi) do
+    YAML.load_file(File.expand_path('../lib/cgminer_monitor/openapi.yml', __dir__))
+  end
+
+  def response_ref(openapi, path)
+    openapi.dig('paths', path, 'get', 'responses', '200',
+                'content', 'application/json', 'schema', '$ref')
+  end
+
+  describe 'components.schemas' do
+    it 'defines SnapshotEnvelope with ok, response, error' do
+      schema = openapi.dig('components', 'schemas', 'SnapshotEnvelope')
+      expect(schema).not_to be_nil
+      expect(schema['properties'].keys).to include('ok', 'response', 'error')
+      expect(schema['required']).to include('ok')
+    end
+
+    it 'defines GraphDataEnvelope with fields, data' do
+      schema = openapi.dig('components', 'schemas', 'GraphDataEnvelope')
+      expect(schema).not_to be_nil
+      expect(schema['properties'].keys).to include('fields', 'data')
+      expect(schema['required']).to include('fields', 'data')
+    end
+  end
+
+  describe 'snapshot endpoints' do
+    snapshot_paths.each do |path|
+      it "#{path} 200 response references SnapshotEnvelope" do
+        expect(response_ref(openapi, path)).to eq('#/components/schemas/SnapshotEnvelope')
+      end
+    end
+  end
+
+  describe 'graph_data endpoints' do
+    graph_paths.each do |path|
+      it "#{path} 200 response references GraphDataEnvelope" do
+        expect(response_ref(openapi, path)).to eq('#/components/schemas/GraphDataEnvelope')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `components.schemas.SnapshotEnvelope` (`{ok, response, error}`) and `components.schemas.GraphDataEnvelope` (`{fields, data}`) to `lib/cgminer_monitor/openapi.yml` and wires `$ref` into the 200 responses for the seven previously-undocumented endpoints:
  - `/v2/miners/{miner}/{summary,stats,devices,pools}` → `SnapshotEnvelope`
  - `/v2/graph_data/{hashrate,temperature,availability}` → `GraphDataEnvelope`
- `SnapshotEnvelope.response` stays declared open (`additionalProperties: true`) — cgminer-firmware payload drift is not part of this envelope contract.
- Bumps `info.version` `"2.0.0"` → `"2.1.0"` (additive, non-breaking; consumers who assumed `additionalProperties: true` by omission see no change).
- Uses OpenAPI-3.1-correct `type: [string, "null"]` instead of the 3.0-era `nullable: true` — the spec already declares `openapi: "3.1.0"`.
- New `spec/openapi_schema_spec.rb` tightens the wiring: every target path must reference one of the two new schemas; both schemas must be defined under `components.schemas` with the expected top-level properties. A future refactor that silently drops a `$ref` fails loudly.

## Scope

The existing `/v2/miners` and `/v2/healthz` inline schemas are untouched — they're already thorough, and inline-vs-`$ref` is a stylistic choice not worth churning.

Companion PR in `cgminer_manager` will pin this release and add a contract test asserting every envelope key `MonitorClient` reads is declared here. Merge + tag `v1.2.0` first so the manager-side PR can pin a stable ref.

## Test plan

- [x] `bundle exec rake` — 156 examples, 0 failures (up from 147 with +9 new); rubocop clean
- [x] `spec/openapi_consistency_spec.rb` path-parity test still passes unchanged
- [x] `spec/openapi_schema_spec.rb` pins the 7 `$ref`s + the 2 `components.schemas` definitions
- [ ] Eyeball the rendered OpenAPI in the Swagger UI (`/docs`) after merge