### PR TITLE
docs(alerts): refresh AGENTS.md + docs/* for alerts feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,8 @@ bundle exec rubocop -A                                 # lint + auto-correct
 
 **Coverage** is always on (SimpleCov in `spec_helper.rb`). Reports in `coverage/` — `.gitignore`d.
 
+**Mermaid validation.** Every `docs/*.md` may contain ` ```mermaid ` blocks. Run `script/validate_mermaid` to lint them all — the script extracts each block and pipes it through `npx @mermaid-js/mermaid-cli`. Requires `node >= 18` and `npx` on PATH. First run is slow (Puppeteer downloads Chromium into `~/.npm/_npx`, ~300 MB; cached after). Not wired into `bundle exec rake` — it's an opt-in local check for docs PRs.
+
 **Manual sandbox** without real miners:
 
 ```sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Consolidated context for AI coding assistants. For end-user docs, see [`README.m
 - [Running tests and lint](#running-tests-and-lint)
 - [Adding a new HTTP endpoint](#adding-a-new-http-endpoint)
 - [Adding a new extracted metric](#adding-a-new-extracted-metric)
+- [Adding a new alert rule](#adding-a-new-alert-rule)
 - [Ruby and Mongo version support](#ruby-and-mongo-version-support)
 - [Gotchas worth knowing up front](#gotchas-worth-knowing-up-front)
 - [Release process](#release-process)
@@ -24,9 +25,9 @@ Consolidated context for AI coding assistants. For end-user docs, see [`README.m
 
 A standalone Ruby daemon that polls [cgminer](https://github.com/ckolivas/cgminer) instances, stores device/pool/summary/stats data in MongoDB, and serves a read-only HTTP API. **Not** a Rails engine anymore — the 1.0 rewrite (April 2026) made it a plain foreground process run under a supervisor (systemd, Docker, launchd).
 
-**Stack:** Ruby 3.2+ (gemspec floor), MongoDB 5.0+ (time-series collections). Runtime deps: `cgminer_api_client ~> 0.3.0`, `mongoid ~> 9.0`, `sinatra >= 4.0`, `puma >= 6.0`, `rack-cors ~> 2.0`. Dev deps: `rspec`, `rubocop` (+ `-rake`, `-rspec`), `rack-test`, `rake`, `simplecov`.
+**Stack:** Ruby 3.2+ (gemspec floor), MongoDB 5.0+ (time-series collections). Runtime deps: `cgminer_api_client ~> 0.3.0`, `mongoid ~> 9.0`, `sinatra >= 4.0`, `puma >= 6.0`, `rack-cors ~> 2.0`. Webhook alerting uses stdlib `Net::HTTP` only — no new runtime gem. Dev deps: `rspec`, `rubocop` (+ `-rake`, `-rspec`), `rack-test`, `rake`, `simplecov`, `webmock >= 3.24` (used by webhook + alerts integration specs; load is scoped to those specs so the other integration specs keep their real-net posture).
 
-**Footprint:** ~1050 SLOC in `lib/`, ~2250 SLOC in `spec/`. Small, well-tested.
+**Footprint:** ~1680 SLOC in `lib/`, ~3420 SLOC in `spec/`. Small, well-tested.
 
 **Execution model:** CLI subcommand `cgminer_monitor run` starts one process with two threads — Poller (cgminer → Mongo) and Puma (HTTP out). SIGTERM/SIGINT → graceful shutdown with timeout, exit 0. Config validation failure → exit 78. Anything else bad → exit 1.
 
@@ -46,13 +47,16 @@ A standalone Ruby daemon that polls [cgminer](https://github.com/ckolivas/cgmine
 │   ├── snapshot.rb                 # Mongoid: latest_snapshot (regular, upserted per poll)
 │   ├── snapshot_query.rb           # Read-side: for_miner, miners, last_poll_at
 │   ├── poller.rb                   # Polling loop, sample extraction, bulk writes to Mongo
+│   ├── alert_evaluator.rb          # Per-miner threshold rules; runs after each poll; fires/resolves state
+│   ├── alert_state.rb              # Mongoid: alert_states (per-(miner, rule) state doc)
+│   ├── webhook_client.rb           # Stdlib Net::HTTP webhook POST w/ generic|slack|discord body
 │   ├── server.rb                   # Orchestrator: signals, Mongoid, Poller, Puma, shutdown
 │   ├── http_app.rb                 # Sinatra app: /v2/*, /metrics, /openapi.yml, /docs
 │   ├── openapi.yml                 # OpenAPI 3.1 (packaged, served at /openapi.yml, CI-guarded)
 │   └── version.rb                  # VERSION = "1.0.0"
 ├── spec/                           # RSpec unit + integration (NOT packaged)
-│   ├── cgminer_monitor/            # Unit specs, one per lib/ file
-│   ├── integration/                # full_pipeline, cli, healthz
+│   ├── cgminer_monitor/            # Unit specs, one per lib/ file (incl. alert_evaluator_spec, webhook_client_spec)
+│   ├── integration/                # full_pipeline, cli, healthz, alerts_integration
 │   ├── openapi_consistency_spec.rb # route ↔ openapi.yml parity guard
 │   └── support/                    # FakeCgminer, CgminerFixtures, mongo_helper
 ├── config/miners.yml.example       # NOT packaged (gemspec omits it deliberately)
@@ -88,7 +92,11 @@ bin/cgminer_monitor run
       │
       ├──spawn Poller thread ──► cgminer_api_client::MinerPool ──TCP──► cgminer instances
       │                              │
-      │                              └──► Sample.insert_many + Snapshot.bulk_write ──► Mongo
+      │                              ├──► Sample.insert_many + Snapshot.bulk_write ──► Mongo
+      │                              │
+      │                              └──► AlertEvaluator (post-poll) ──► AlertState upserts
+      │                                          │
+      │                                          └──► WebhookClient ──HTTPS──► webhook sink
       │
       └──spawn Puma thread ──► HttpApp ──► SampleQuery / SnapshotQuery ──► Mongo
 
@@ -104,6 +112,7 @@ bin/cgminer_monitor run
 5. **`Sample.store_in` is called at runtime**, not as a class macro, because the `expire_after` depends on `Config#retention_seconds`. `Sample.create_collection` is called explicitly so the collection is actually time-series (not a regular lazy-created one).
 6. **Poller bypasses `CgminerApiClient::MinerPool.new`** because that constructor hard-codes `'config/miners.yml'` relative to CWD — which doesn't honor `CGMINER_MONITOR_MINERS_FILE`. Uses `MinerPool.allocate` + manual `.miners=`.
 7. **OpenAPI is source of truth.** `spec/openapi_consistency_spec.rb` walks `HttpApp`'s routes and checks against `lib/cgminer_monitor/openapi.yml`. Adding/removing routes requires updating the YAML in the same commit.
+8. **Alerts are opt-in and post-poll.** `AlertEvaluator` runs *after* the `poll.complete` log line in the Poller thread (preserves `poll.complete` as a clean "poll finished and persisted" signal). Disabled by default (`CGMINER_MONITOR_ALERTS_ENABLED=false`); early-returns before any work. When enabled, reads the just-written `Snapshot` collection for hashrate/temperature and the `Sample` time-series for the offline rule's "seconds since last successful poll" — see `docs/components.md`/`docs/workflows.md`. Webhook POST is stdlib `Net::HTTP` with a 2s timeout, no retry; failures are logged as `alert.webhook_failed` and the poll loop continues.
 
 ## Conventions that matter when editing code
 
@@ -211,6 +220,27 @@ bundle exec bin/cgminer_monitor run
 4. **If the metric becomes part of Prometheus exposition**, update `HttpApp#build_prometheus_metrics` and add `# HELP` / `# TYPE` lines.
 5. **Tests:** exercise the new extraction via an integration spec using `FakeCgminer` fixtures, not just unit-level mocks.
 
+## Adding a new alert rule
+
+<!-- metadata: extending, how-to, alerts -->
+
+The alerts feature (see `docs/components.md` → AlertEvaluator) ships three rules: `hashrate_below`, `temperature_above`, `offline`. Adding a fourth means editing three places in lockstep:
+
+1. **Threshold config.** Add a `CGMINER_MONITOR_ALERTS_<NAME>` env var to the 8 already wired up in `lib/cgminer_monitor/config.rb` (search for `alerts_hashrate_min_ghs` to find the block). A `nil` default means the rule is opt-in per-deployment; the `validate_alerts!` helper already enforces "alerts_enabled=true requires at least one rule configured" across all rules in the block.
+
+2. **AlertEvaluator wiring** in `lib/cgminer_monitor/alert_evaluator.rb`:
+   - Add the rule name to the `RULES` constant.
+   - Add its unit to `UNITS` (so the webhook body's `unit` key is populated consistently).
+   - Add a `threshold_for` branch (maps rule → config field).
+   - Add a `violates?` branch (the comparison; `>`, `<`, `>=`, etc.).
+   - Extend `miner_states(now)` to populate the new reading per miner. **Defensively guard shape assumptions** in whatever `extract_*` helper you add — a `TypeError` from one malformed cgminer response would drop alert evaluation for every other miner on the tick. See the existing `extract_hashrate` / `extract_temperature` helpers for the `is_a?(Hash)` / `is_a?(Array)` pattern.
+
+3. **Docs + log schema.** Extend the reservation in `docs/log_schema.md` (the `alert.*` namespace) with the new rule name in the `rule` enum. Add a row to the env-var table in `docs/interfaces.md` and a paragraph in `docs/components.md`. If the rule needs a new standard key, reserve it there too.
+
+4. **Tests.** Cover all 7 transition-table rows (see `spec/cgminer_monitor/alert_evaluator_spec.rb`) for the new rule. Add a WebMock-stubbed case in `spec/integration/alerts_integration_spec.rb` if the rule's extraction is non-trivial.
+
+**Don't add severity tiers piecemeal.** The `severity` key in the webhook body is fixed to `"warning"` for v1; if a rule needs a `critical` tier, plan the full two-tier transition (config, body, and at least one receiver recipe) in one PR.
+
 ## Ruby and Mongo version support
 
 <!-- metadata: runtime, compatibility -->
@@ -276,8 +306,9 @@ Container images (Docker Hub / GHCR) are not currently pushed by CI. If that hap
 | How do the classes relate architecturally? Why two threads? Why this signal dance? | [`docs/architecture.md`](docs/architecture.md) |
 | What does each class do? | [`docs/components.md`](docs/components.md) |
 | What's the public method signature for X? HTTP endpoint Y? env var Z? | [`docs/interfaces.md`](docs/interfaces.md) |
-| What's in a `Sample`? What's in `latest_snapshot`? What errors can be raised? | [`docs/data_models.md`](docs/data_models.md) |
-| How does a poll cycle flow? How does startup/shutdown work? Release process? | [`docs/workflows.md`](docs/workflows.md) |
+| What's in a `Sample`? What's in `latest_snapshot`? What's in `alert_states`? What errors can be raised? | [`docs/data_models.md`](docs/data_models.md) |
+| How does a poll cycle flow? How does alert evaluation hook in? How does startup/shutdown work? Release process? | [`docs/workflows.md`](docs/workflows.md) |
+| Which log events does the app emit, which namespace, which keys? (`alert.*`, `poll.*`, etc.) | [`docs/log_schema.md`](docs/log_schema.md) |
 | Runtime deps? Why Mongo 5+? CI matrix? | [`docs/dependencies.md`](docs/dependencies.md) |
 | Known doc/code drift, caveats, cleanup recommendations | [`docs/review_notes.md`](docs/review_notes.md) |
 | Full knowledge-base index | [`docs/index.md`](docs/index.md) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ sequenceDiagram
     end
 
     Puma->>Puma: serve /v2/* requests
-    Note over Puma: concurrent; isolated from Poller
+    Note over Puma: concurrent, isolated from Poller
 
     Note over Main: SIGTERM arrives
     Main->>Queue: signal pushed
@@ -134,7 +134,7 @@ sequenceDiagram
     Poller->>Poller: Logger.info 'poll.complete'
     opt alerts_enabled
         Poller->>Poller: AlertEvaluator#evaluate(now)
-        Note over Poller: rescue StandardError → alert.evaluator_error; poll loop continues
+        Note over Poller: rescue StandardError → alert.evaluator_error, poll loop continues
     end
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,13 +132,18 @@ sequenceDiagram
     Snapshot->>Mongo: (upsert many)
 
     Poller->>Poller: Logger.info 'poll.complete'
+    opt alerts_enabled
+        Poller->>Poller: AlertEvaluator#evaluate(now)
+        Note over Poller: rescue StandardError → alert.evaluator_error; poll loop continues
+    end
 ```
 
 **Key observations:**
 - `extract_samples` normalizes keys (`"GHS 5s"` → `ghs_5s`, `"Pool Rejected%"` → `pool_rejected_pct`) and only keeps numeric values. String fields (device status, pool URL) are dropped from the samples collection but preserved in full in `latest_snapshot`.
-- Each miner also emits two synthetic per-poll samples: `{command: 'poll', metric: 'ok', v: 0|1}` and `{command: 'poll', metric: 'duration_ms', v: ...}`. These drive the availability graph and the Prometheus `cgminer_available` gauge.
+- Each miner also emits two synthetic per-poll samples: `{command: 'poll', metric: 'ok', v: 0|1}` and `{command: 'poll', metric: 'duration_ms', v: ...}`. These drive the availability graph, the Prometheus `cgminer_available` gauge, **and** the alert evaluator's `offline` rule — which reads the `Sample` time-series (not `Snapshot`, which overwrites `ok` on failure) to answer "seconds since this miner last succeeded."
 - `bulk_write(..., ordered: false)` means snapshot upserts don't short-circuit on the first failure — each miner's snapshot has an independent chance to succeed.
 - Errors at Mongo level are logged and counted; they don't re-raise out of `poll_once`. So a transient Mongo outage degrades polling silently (stats recorded in `polls_failed`) rather than crashing the process.
+- The alert evaluator runs *after* `poll.complete` is logged, so `poll.complete` stays a clean "poll finished and persisted" signal (useful for detecting poll-loop stalls). A slow webhook delays the next poll by at most the configured webhook timeout (`CGMINER_MONITOR_ALERTS_WEBHOOK_TIMEOUT_SECONDS`, default 2s).
 
 ## Request lifecycle (read path)
 
@@ -213,6 +218,9 @@ A shared `Queue` is the rendezvous point for "time to stop." Signal handlers pus
 
 ### Bypass pattern for cgminer_api_client's MinerPool
 `CgminerApiClient::MinerPool.new` hard-codes `'config/miners.yml'` relative to CWD. That doesn't honor monitor's `CGMINER_MONITOR_MINERS_FILE`. So `Poller#build_miner_pool` uses `MinerPool.allocate` and sets `.miners=` directly. It's an intentional escape hatch; if api_client ever grows a constructor that accepts a path, we can delete that ceremony.
+
+### Alert state machine per (miner, rule)
+`AlertEvaluator` is a small state machine with two states (`ok` / `violating`) and a per-(miner, rule) `AlertState` document. Transitions emit `alert.fired` (healthy → violating) and `alert.resolved` (violating → healthy); a cooldown window (`CGMINER_MONITOR_ALERTS_COOLDOWN_SECONDS`, default 300s) re-emits `alert.fired` while a rule stays violating, so receivers that drop a notification get re-paged. The state doc's `_id` is a composite string `"#{miner}|#{rule}"` so Mongo's implicit `_id` index enforces uniqueness without a secondary index. See `data_models.md` for the document shape and `workflows.md` for the transition table.
 
 ### OpenAPI as source of truth, enforced by CI
 `spec/openapi_consistency_spec.rb` walks `HttpApp`'s registered routes and cross-checks them against `lib/cgminer_monitor/openapi.yml`. Drift fails CI. The OpenAPI doc is packaged with the gem and served at `/openapi.yml`; `/docs` embeds Swagger UI.

--- a/docs/codebase_info.md
+++ b/docs/codebase_info.md
@@ -138,7 +138,7 @@ graph TB
 
     HttpApp -->|reads via| SampleQ
     HttpApp -->|reads via| SnapshotQ
-    HttpApp -.reads settings.poller.-> Poller
+    HttpApp -.->|reads settings.poller| Poller
     SampleQ -->|queries| Sample
     SnapshotQ -->|queries| Snapshot
 

--- a/docs/codebase_info.md
+++ b/docs/codebase_info.md
@@ -15,8 +15,8 @@ At runtime the process has two threads:
 - **Language:** Ruby 3.2+ (gemspec `required_ruby_version`).
 - **CI matrix:** Ruby 3.2/3.3/3.4 required × Mongo 6/7. Ruby 4.0 and `head` are best-effort (Mongoid 9 doesn't officially support them yet).
 - **Storage:** MongoDB 5.0+. 5.0 is the minimum for time-series collections; 6.0 is what the GitHub Actions matrix tests against because it's the earliest Mongo version available in `services:` runners.
-- **Runtime gem deps:** `cgminer_api_client ~> 0.3.0`, `mongoid ~> 9.0`, `sinatra >= 4.0`, `puma >= 6.0`, `rack-cors ~> 2.0`.
-- **Dev deps:** `rspec >= 3.13`, `rack-test >= 2.1`, `rubocop >= 1.60` (+ `-rake`, `-rspec`), `rake >= 13.2`, `simplecov >= 0.22`.
+- **Runtime gem deps:** `cgminer_api_client ~> 0.3.0`, `mongoid ~> 9.0`, `sinatra >= 4.0`, `puma >= 6.0`, `rack-cors ~> 2.0`. Alert webhook delivery uses stdlib `Net::HTTP` — no additional runtime gem.
+- **Dev deps:** `rspec >= 3.13`, `rack-test >= 2.1`, `rubocop >= 1.60` (+ `-rake`, `-rspec`), `rake >= 13.2`, `simplecov >= 0.22`, `webmock >= 3.24` (scoped to webhook + alerts integration specs).
 - **Test framework:** RSpec. Unit specs at `spec/cgminer_monitor/**`, integration specs at `spec/integration/`, plus a top-level `spec/openapi_consistency_spec.rb` that CI uses to enforce route↔openapi.yml parity.
 - **Lint:** RuboCop with `TargetRubyVersion: 3.2`. Default rake task runs spec + rubocop.
 - **Coverage:** SimpleCov, filter `/spec/`; reports to `coverage/`.
@@ -39,6 +39,9 @@ cgminer_monitor/
 │       ├── snapshot.rb              # Mongoid regular model (latest_snapshot collection)
 │       ├── snapshot_query.rb        # Read-side: for_miner, miners, last_poll_at
 │       ├── poller.rb                # Polling loop, sample extraction, bulk writes
+│       ├── alert_evaluator.rb       # Post-poll: evaluate threshold rules, fire/resolve, call WebhookClient
+│       ├── alert_state.rb           # Mongoid regular model (alert_states collection); composite _id "miner|rule"
+│       ├── webhook_client.rb        # Stdlib Net::HTTP::Post; generic | slack | discord body formats
 │       ├── server.rb                # Orchestrator: Mongoid config, Poller thread, Puma thread, signal handling
 │       ├── http_app.rb              # Sinatra app: /v2/* endpoints, Prometheus, /docs, /openapi.yml
 │       ├── openapi.yml              # OpenAPI 3.1 spec (served at /openapi.yml, lint-checked in CI)
@@ -46,10 +49,11 @@ cgminer_monitor/
 ├── spec/
 │   ├── spec_helper.rb               # SimpleCov + require_relative support/**
 │   ├── cgminer_monitor_spec.rb
-│   ├── cgminer_monitor/             # Unit specs, one per lib/ file
+│   ├── cgminer_monitor/             # Unit specs, one per lib/ file (incl. alert_evaluator_spec, webhook_client_spec)
 │   ├── integration/
 │   │   ├── cli_spec.rb              # Spawns the real bin/ via Open3
 │   │   ├── full_pipeline_spec.rb    # FakeCgminer + Poller + Mongo + HttpApp end-to-end
+│   │   ├── alerts_integration_spec.rb # WebMock-stubbed webhook + real Mongo; fire→resolve + cooldown re-fire
 │   │   └── healthz_spec.rb          # State transitions: starting → healthy → degraded
 │   ├── openapi_consistency_spec.rb  # CI guard: routes vs openapi.yml
 │   └── support/
@@ -93,6 +97,9 @@ graph TB
     Config[CgminerMonitor::Config]
     Server[CgminerMonitor::Server]
     Poller[CgminerMonitor::Poller]
+    Alerts[CgminerMonitor::AlertEvaluator]
+    AlertState[CgminerMonitor::AlertState]
+    Webhook[CgminerMonitor::WebhookClient]
     HttpApp[CgminerMonitor::HttpApp]
     Puma[Puma::Launcher]
     Logger[CgminerMonitor::Logger]
@@ -103,6 +110,7 @@ graph TB
     APIClient[CgminerApiClient::MinerPool]
     Mongo[(MongoDB)]
     Cgminer[cgminer instances]
+    WebhookSink[webhook sink: Slack/Discord/generic]
 
     CLI -->|run| Server
     CLI -->|migrate| Sample
@@ -120,6 +128,14 @@ graph TB
     Poller -->|insert_many| Sample
     Poller -->|bulk_write| Snapshot
 
+    Poller -->|evaluate after poll| Alerts
+    Alerts -->|reads| Snapshot
+    Alerts -->|reads offline from| SampleQ
+    Alerts -->|upsert| AlertState
+    Alerts -->|fire or resolve| Webhook
+    Webhook -->|HTTPS POST| WebhookSink
+    AlertState -->|persists to| Mongo
+
     HttpApp -->|reads via| SampleQ
     HttpApp -->|reads via| SnapshotQ
     HttpApp -.reads settings.poller.-> Poller
@@ -132,6 +148,8 @@ graph TB
     Poller -.-> Logger
     Server -.-> Logger
     HttpApp -.-> Logger
+    Alerts -.-> Logger
+    Webhook -.-> Logger
 ```
 
 ## Key facts worth knowing up front
@@ -144,6 +162,7 @@ graph TB
 6. **The samples collection is a MongoDB time-series collection** (Mongo 5.0+ feature) with an `expire_after` TTL matching `CGMINER_MONITOR_RETENTION_SECONDS`. `cgminer_monitor migrate` (or `Server#bootstrap_mongoid!`) does the `create_collection` call.
 7. **No authentication on the HTTP API.** Designed for trusted networks. Put a reverse proxy in front of it if you're exposing it beyond that.
 8. **`cgminer_api_client` is a hard runtime dependency.** The `Poller` bypasses `CgminerApiClient::MinerPool.new` (which hard-codes a `config/miners.yml` path relative to CWD) by allocating the pool and setting `.miners=` directly, so it can honor the configurable `CGMINER_MONITOR_MINERS_FILE`.
+9. **Alerts are opt-in.** `CGMINER_MONITOR_ALERTS_ENABLED=false` by default, so the default deploy carries zero alert surface (Prometheus users keep their existing pipeline). When enabled, `AlertEvaluator` runs in the Poller thread after the `poll.complete` log, reads the freshly-written `Snapshot` collection (hashrate / temperature) and the `Sample` time-series (offline rule — "seconds since last successful poll"), upserts per-(miner, rule) state into `alert_states`, and POSTs to the configured webhook URL via stdlib `Net::HTTP`. No retry; failures log `alert.webhook_failed` and the poll loop continues.
 
 ## Version and release posture
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -12,7 +12,7 @@ From the gemspec:
 | `puma` | `>= 6.0` | HTTP server. Embedded via `Puma::Configuration` + `Puma::Launcher`. |
 | `rack-cors` | `~> 2.0` | CORS middleware. Configured from `CGMINER_MONITOR_CORS_ORIGINS`. |
 
-Plus the Ruby stdlib pieces: `json`, `socket`, `yaml`, `cgi/escape`, `time`.
+Plus the Ruby stdlib pieces: `json`, `socket`, `yaml`, `cgi/escape`, `time`, `net/http` + `uri` (used by `WebhookClient` so the alerts feature adds no runtime gem dependency).
 
 **One conditional dependency.** `Gemfile` adds `gem 'ostruct' if RUBY_VERSION >= '3.5'` because Ruby 4.0 moved `ostruct` out of default gems and Mongoid 9 hasn't caught up yet. This is a compatibility shim, not a feature dep — `ostruct` is used by Mongoid internals, not by our code.
 
@@ -31,6 +31,7 @@ group :development do
   gem 'rubocop-rake',  '>= 0.6'
   gem 'rubocop-rspec', '>= 3.0'
   gem 'simplecov',     '>= 0.22'
+  gem 'webmock',       '>= 3.24'
 end
 ```
 
@@ -42,6 +43,7 @@ end
 | `rubocop` | Linter. `.rubocop.yml` has `TargetRubyVersion: 3.2` and turns off most `Metrics/*` cops. |
 | `rubocop-rake` / `rubocop-rspec` | RuboCop plugin cops for Rake and RSpec styles. |
 | `simplecov` | Code coverage. Starts in `spec_helper.rb`. |
+| `webmock` | Stubs `Net::HTTP` in the alerts integration spec and the webhook-client unit spec. Loaded *only* inside those specs via a scoped `require 'webmock/rspec'` — the CLI reload integration spec depends on real local HTTP and must not be affected. |
 
 ## Ruby version support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,10 +16,11 @@
 | "what is this project?" / stack / file tree / module graph | [`codebase_info.md`](codebase_info.md) |
 | two-thread execution model / signal-handler dance / graceful shutdown / why things are shaped this way | [`architecture.md`](architecture.md) |
 | what each class/module does / responsibilities / where to find X | [`components.md`](components.md) |
-| HTTP API contracts / CLI exit codes / env-var table / `miners.yml` schema / structured-log schema | [`interfaces.md`](interfaces.md) |
-| MongoDB collection shapes / `Sample`/`Snapshot` fields / `Config` invariants / error hierarchy | [`data_models.md`](data_models.md) |
-| startup / polling loop / HTTP request lifecycle / test harness / release process | [`workflows.md`](workflows.md) |
-| runtime + dev deps / Ruby + Mongo version floors / CI matrix | [`dependencies.md`](dependencies.md) |
+| HTTP API contracts / CLI exit codes / env-var table (incl. `CGMINER_MONITOR_ALERTS_*`) / `miners.yml` schema / structured-log schema | [`interfaces.md`](interfaces.md) |
+| MongoDB collection shapes / `Sample`/`Snapshot`/`alert_states` fields / `Config` invariants / error hierarchy | [`data_models.md`](data_models.md) |
+| startup / polling loop / alert evaluation flow / HTTP request lifecycle / test harness / release process | [`workflows.md`](workflows.md) |
+| runtime + dev deps (incl. stdlib `Net::HTTP` for webhooks, `webmock` for alert specs) / Ruby + Mongo version floors / CI matrix | [`dependencies.md`](dependencies.md) |
+| structured log event catalog / reserved namespaces (`poll.*`, `alert.*`, `http.*`, …) / standard keys | [`log_schema.md`](log_schema.md) |
 | known gaps, inconsistencies, caveats in the docs themselves / cleanup recommendations | [`review_notes.md`](review_notes.md) |
 
 ## Document summaries
@@ -42,6 +43,9 @@
 ### [`workflows.md`](workflows.md)
 **Purpose:** Sequence diagrams and step-by-step flows. Startup, polling, request handling, graceful shutdown. Dev test workflow (unit, integration, openapi-check). Docker Compose dev stack. Release process. **Read this to understand how code paths compose over time.**
 
+### [`log_schema.md`](log_schema.md)
+**Purpose:** Reserved namespaces and event catalog for the structured logger. Documents every event name, required vs optional keys, and the four "standard keys" (`rule`, `threshold`, `observed`, `unit`) added with the alerts feature. **Read this to find "what log lines does the app emit for X?" or before adding a new event.**
+
 ### [`dependencies.md`](dependencies.md)
 **Purpose:** Runtime deps (cgminer_api_client, mongoid, sinatra, puma, rack-cors) and dev deps. Ruby/Mongo version rationale. CI matrix (lint/test/integration/openapi-check jobs). Mongoid 9 ↔ BSON 6 constraint. **Read this for "can I add gem X?", "what Rubies does this support?", or "why is Mongoid pinned."**
 
@@ -60,6 +64,9 @@
 | "Can I run this with MongoDB 4.4?" | `dependencies.md` (Mongo version support) — no, time-series requires 5.0+ |
 | "What's the schema of the `/v2/graph_data/hashrate` response?" | `interfaces.md` (HTTP API → Graph data) |
 | "Where does cgminer's `\"Pool Rejected%\"` end up in Mongo?" | `data_models.md` (Sample meta shape) — `metric: "pool_rejected_pct"` |
+| "How do I wire up alerts to a Slack webhook?" | `README.md` (Alerts subsection, 8 env vars + Slack example) + `interfaces.md` (env-var table) |
+| "How does the offline-rule know when a miner last succeeded?" | `components.md` (AlertEvaluator) + `workflows.md` (alert evaluation) — it reads the `Sample` time-series, not `Snapshot`, because Snapshot overwrites `ok` on failure |
+| "Why did I get paged again while the miner is still below target?" | `log_schema.md` (`alert.fired` w/ cooldown) + `data_models.md` (`alert_states.last_fired_at`) — cooldown-gated re-fire |
 
 ## Maintenance note
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -74,8 +74,16 @@ All knobs are `ENV` reads at boot via `Config.from_env`. Defaults in parentheses
 | `CGMINER_MONITOR_SHUTDOWN_TIMEOUT` | `10` | Seconds to wait for each of Poller and Puma to stop during graceful shutdown. |
 | `CGMINER_MONITOR_HEALTHZ_STALE_MULTIPLIER` | `2` | Stale threshold = `interval * multiplier` seconds since last poll before `/healthz` returns `degraded`. |
 | `CGMINER_MONITOR_HEALTHZ_STARTUP_GRACE` | `60` | Seconds after boot during which a missing poll still reports `starting` rather than `degraded`. |
+| `CGMINER_MONITOR_ALERTS_ENABLED` | `false` | Master switch for the per-miner alerts feature. When `false`, the evaluator early-returns and zero alert surface is exercised. Accepts `1`/`true`/`yes`/`on` (and their negatives), case-insensitive. |
+| `CGMINER_MONITOR_ALERTS_WEBHOOK_URL` | *(none)* | Required when `ALERTS_ENABLED=true`. Must be `http(s)://<host>[:port]/…` with a non-empty host. Validated at boot. |
+| `CGMINER_MONITOR_ALERTS_WEBHOOK_FORMAT` | `generic` | Webhook body shape. One of `generic` (JSON contract documented in `log_schema.md`), `slack` (Slack incoming-webhook `attachments[]` with color sidebar), or `discord` (Discord `embeds[]` with decimal RGB). |
+| `CGMINER_MONITOR_ALERTS_HASHRATE_MIN_GHS` | *(none)* | Float; per-miner hashrate floor in GH/s. Rule disabled when unset. Fires `alert.fired` / `rule: "hashrate_below"` when the per-miner `SUMMARY.GHS 5s` drops below this. |
+| `CGMINER_MONITOR_ALERTS_TEMPERATURE_MAX_C` | *(none)* | Float; per-miner temperature ceiling in °C (max-over-chips, matching the operator-visible view). Rule disabled when unset. |
+| `CGMINER_MONITOR_ALERTS_OFFLINE_AFTER_SECONDS` | *(none)* | Integer; fires when `now - last_ok_sample_ts` exceeds this. Rule disabled when unset. Falls back to the miner's earliest poll sample when no successful poll has ever been observed. |
+| `CGMINER_MONITOR_ALERTS_COOLDOWN_SECONDS` | `300` | Integer > 0. While a rule stays violating, re-emits `alert.fired` every `cooldown_seconds` so consumers that drop a notification get re-paged. |
+| `CGMINER_MONITOR_ALERTS_WEBHOOK_TIMEOUT_SECONDS` | `2` | Integer > 0. Both open and read timeout for the `Net::HTTP::Post` call. Caps how much a slow webhook can delay the next poll. |
 
-`Config#validate!` fails hard on: non-positive `interval`, unknown `log_format`, nonexistent `miners_file`, unknown `log_level`. Integer parse errors surface the offending env var name verbatim.
+`Config#validate!` fails hard on: non-positive `interval`, unknown `log_format`, nonexistent `miners_file`, unknown `log_level`. Integer parse errors surface the offending env var name verbatim. When `ALERTS_ENABLED=true`, a separate `validate_alerts!` block additionally requires: webhook URL present + host-nonempty + scheme in `{http, https}`; format in `{generic, slack, discord}`; **at least one** of `HASHRATE_MIN_GHS` / `TEMPERATURE_MAX_C` / `OFFLINE_AFTER_SECONDS` set (empty-but-defined floats/ints fail loudly rather than silently disabling a rule).
 
 ## 3. `miners.yml`
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -63,7 +63,7 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
-    participant Loop as run_until_stopped
+    participant Runner as run_until_stopped
     participant Clock
     participant Poller as poll_once
     participant Pool as CgminerApiClient::MinerPool
@@ -76,8 +76,8 @@ sequenceDiagram
     participant Sleep as interruptible_sleep
 
     loop until @stopped
-        Loop->>Clock: started_at = CLOCK_MONOTONIC
-        Loop->>Poller: poll_once
+        Runner->>Clock: started_at = CLOCK_MONOTONIC
+        Runner->>Poller: poll_once
 
         loop each of [summary, devs, pools, stats]
             Poller->>Pool: pool.query(command)
@@ -110,8 +110,8 @@ sequenceDiagram
             Note over Poller: rescues StandardError, logs alert.evaluator_error
         end
 
-        Loop->>Clock: elapsed = CLOCK_MONOTONIC - started_at
-        Loop->>Sleep: remaining = interval - elapsed
+        Runner->>Clock: elapsed = CLOCK_MONOTONIC - started_at
+        Runner->>Sleep: remaining = interval - elapsed
         alt remaining > 0
             Sleep->>Sleep: @cv.wait(@mutex, remaining) unless @stopped
         end

--- a/script/validate_mermaid
+++ b/script/validate_mermaid
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Lint every ```mermaid block under docs/ by feeding it to
+# @mermaid-js/mermaid-cli via npx. Exits non-zero on any parse error.
+#
+# Requires: node >= 18 and npx on PATH. First run downloads Puppeteer
+# + Chromium into ~/.npm/_npx (~300 MB, cached after).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+echo '{"args":["--no-sandbox"]}' > "$tmp/puppeteer.json"
+
+for md in docs/*.md; do
+  base=$(basename "$md" .md)
+  awk -v t="$tmp" -v b="$base" '
+    BEGIN {n = 0}
+    /^```mermaid$/ {capture = 1; n++; f = sprintf("%s/%s__%d.mmd", t, b, n); next}
+    /^```$/ && capture {capture = 0; next}
+    capture {print > f}
+  ' "$md"
+done
+
+total=0
+fail=0
+for mmd in "$tmp"/*.mmd; do
+  [ -e "$mmd" ] || continue
+  total=$((total + 1))
+  if ! npx -y @mermaid-js/mermaid-cli -p "$tmp/puppeteer.json" \
+       -i "$mmd" -o "${mmd%.mmd}.svg" >/dev/null 2>&1; then
+    echo "FAIL: $(basename "$mmd")"
+    npx -y @mermaid-js/mermaid-cli -p "$tmp/puppeteer.json" \
+      -i "$mmd" -o /dev/null 2>&1 | grep -E "Parse|Lexical" | head -2 | sed 's/^/  /'
+    fail=$((fail + 1))
+  fi
+done
+
+echo "$((total - fail)) passed, $fail failed (of $total blocks)"
+exit $fail


### PR DESCRIPTION
## Summary

PR #13 (per-miner alerts with webhook sink) updated the four docs files that got direct new content — `log_schema.md`, `components.md`, `data_models.md`, `workflows.md`. This completes the pass across the other five files that needed a lighter touch, plus `AGENTS.md` which lagged entirely.

**Five commits, one file each:**

1. `docs(agents): refresh AGENTS.md for alerts feature` — add `AlertEvaluator` / `AlertState` / `WebhookClient` to the component flow diagram, repo layout, "key structural facts," and the deep-context navigation table. Add a new "Adding a new alert rule" section symmetric to the existing "Adding a new HTTP endpoint" / "Adding a new extracted metric" sections. Refresh the SLOC footprint (~1680 lib, ~3420 spec).
2. `docs(codebase_info): refresh file tree + module graph for alerts` — Mermaid module graph picks up `AlertEvaluator`, `AlertState`, `WebhookClient`, and the external webhook sink.
3. `docs(index): route alert questions to the right files` — question→file map and example-queries table gain alerts rows; adds a dedicated summary for `log_schema.md`.
4. `docs(architecture): add AlertEvaluator to the write-path diagram` — poll sequence diagram gains the post-poll evaluator call (opt block + rescue note); Design Patterns section gains the (miner, rule) state-machine entry.
5. `docs(interfaces,deps): document alerts env vars + stdlib/webmock deps` — eight `CGMINER_MONITOR_ALERTS_*` env vars in the interfaces env table with fail-loud validation notes; `net/http` + `uri` in the stdlib list; `webmock >= 3.24` as a scoped dev dep.

Docs-only, no code changes.

## Test plan

- [x] `bundle exec rake` green on the branch (230 examples, 0 failures; rubocop 0 offenses).
- [x] `git diff --stat origin/develop..` — 5 files touched, all under `docs/` or `AGENTS.md`.
- [ ] Eyeball the rendered Mermaid diagrams in the PR preview.