### PR TITLE
Fix Phase 1 review findings: env-var name + cgminer.wire optional fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `admin.auth_misconfigured`, `http.request`, `http.500`,
   `http.unhandled_error`, `monitor.call`, `monitor.call.failed`,
   `rate_limit.exceeded` (was previously documented only for
-  `admin.command` / `admin.result`). Implementations follow in
-  `cgminer_monitor` v1.3.0 and `cgminer_manager` v1.6.0 — schema is a
+  `admin.command` / `admin.result`). Implementations follow in upcoming
+  `cgminer_monitor` and `cgminer_manager` releases — schema is a
   forward-looking contract until then.
 - Test-support code (FakeCgminer, CgminerFixtures) extracted to the
   shared `cgminer_test_support` gem. `spec/support/mongo_helper.rb`

--- a/docs/log_schema.md
+++ b/docs/log_schema.md
@@ -88,7 +88,7 @@ Keys that appear across multiple events are named consistently. When you add a n
 - Manager generates `request_id` for every inbound HTTP request via Rack middleware sitting above `RateLimiter` and `AdminAuth`. Stashed on `env['cgminer_manager.request_id']`.
 - Monitor reads `HTTP_X_CGMINER_REQUEST_ID` from inbound requests; if absent (e.g., direct `curl`, Prometheus scraper), generates its own UUID. Stashed on `env['cgminer_monitor.request_id']`.
 - Manager's `MonitorClient` injects `X-Cgminer-Request-Id` on every outbound HTTP call to monitor.
-- Manager's `FleetBuilders` builds per-request `Miner` instances with a closure-captured `on_wire` callback; api_client's wire telemetry surfaces as `cgminer.wire` log events tagged with the request_id (debug level — opt in via `CGMINER_MANAGER_LOG_LEVEL=debug` to avoid the ~100-200 events per fan-out at info volume).
+- Manager's `FleetBuilders` builds per-request `Miner` instances with a closure-captured `on_wire` callback; api_client's wire telemetry surfaces as `cgminer.wire` log events tagged with the request_id (debug level — opt in via `LOG_LEVEL=debug` to avoid the ~100-200 events per fan-out at info volume).
 
 **Reserved-name discipline.** The header is `X-Cgminer-Request-Id` (canonical casing, but HTTP is case-insensitive). Don't introduce alternative names (`X-Trace-Id`, `X-Correlation-Id`).
 
@@ -144,11 +144,11 @@ Organized alphabetically within namespace. "Required" columns list keys beyond t
 
 ### `cgminer.*` (cgminer_manager)
 
-Manager's per-command wire telemetry, emitted at debug level (opt-in via `CGMINER_MANAGER_LOG_LEVEL=debug`). Closure-captured `request_id` flows through every event so a single value recovers the full causal chain across an admin POST → fan-out → cgminer round-trip.
+Manager's per-command wire telemetry, emitted at debug level (opt-in via `LOG_LEVEL=debug`). Closure-captured `request_id` flows through every event so a single value recovers the full causal chain across an admin POST → fan-out → cgminer round-trip.
 
 | Event | Level | Emitter | Required keys | Optional |
 |-------|-------|---------|---------------|----------|
-| `cgminer.wire` | debug | `FleetBuilders.build_wire_logger` (closure passed as `on_wire:` to per-request `CgminerApiClient::Miner` instances) | `request_id`, `direction`, `miner`, `payload` | |
+| `cgminer.wire` | debug | `FleetBuilders.build_wire_logger` (closure passed as `on_wire:` to per-request `CgminerApiClient::Miner` instances) | `request_id`, `direction`, `miner`, `payload` | `duration_ms` (response only — closure-computed delta from request `Time.now`), `bytes` (payload length) |
 
 ### `alert.*` (cgminer_monitor)
 


### PR DESCRIPTION
Fast-follow on PR #17 absorbing three high-confidence findings from a staff review of that PR:

1. **`LOG_LEVEL` is the correct env var, not `CGMINER_MANAGER_LOG_LEVEL`.** Confirmed at \`lib/cgminer_manager/config.rb:55\` (\`env.fetch('LOG_LEVEL', 'info')\`). Two references in \`docs/log_schema.md\` corrected.

2. **\`cgminer.wire\` Optional column gains \`duration_ms\` and \`bytes\`.** \`duration_ms\` is response-only and closure-computed (delta from request \`Time.now\`); \`bytes\` is payload length. Both are forward doors for slow-miner / payload-size debugging without forcing a future \`cgminer_api_client\` signature change.

3. **CHANGELOG forward-version pin softened.** Was \"v1.3.0 and v1.6.0\" — hotfixes shipping between phases would have made the pin wrong at release time. Now \"upcoming releases.\"

## Test plan

- [x] \`bundle exec rake\` clean (46 files, no offenses)
- [x] No semantic schema change beyond what was in PR #17