### PR TITLE
Fix Phase 2 review: dual-emit http.request, drop ivar asymmetry, wire response-header refs

### DIFF
--- a/lib/cgminer_monitor/http_app.rb
+++ b/lib/cgminer_monitor/http_app.rb
@@ -94,20 +94,12 @@ module CgminerMonitor
     end
 
     before do
-      @request_id = request.env[CgminerMonitor::RequestId::ENV_KEY]
       @started_at = Time.now
       content_type :json
     end
 
     after do
-      Logger.info(
-        event: 'http.request',
-        request_id: @request_id,
-        method: request.request_method,
-        path: request.path_info,
-        status: response.status,
-        duration_ms: ((Time.now - @started_at) * 1000).round
-      )
+      log_http_request
     end
 
     # --- Health ---
@@ -265,10 +257,32 @@ module CgminerMonitor
                    backtrace: err.backtrace&.first(10))
       content_type :json
       status 500
-      JSON.generate({ error: 'internal', code: 'internal' })
+      body = JSON.generate({ error: 'internal', code: 'internal' })
+      # Sinatra skips after-filters on the error path. Emit http.request
+      # explicitly so dashboards counting "all requests" via this event
+      # don't undercount errors. Same shape as the success path; matches
+      # cgminer_manager's existing http.request after-filter behavior.
+      log_http_request
+      body
     end
 
     private
+
+    # Single source of truth for http.request emission. Called from the
+    # success path's after-filter and from the error block — Sinatra
+    # skips after-filters when error fires, so explicit emission from
+    # both paths gives a uniform "every request emits one http.request"
+    # invariant matching cgminer_manager's existing behavior.
+    def log_http_request
+      Logger.info(
+        event: 'http.request',
+        request_id: env[CgminerMonitor::RequestId::ENV_KEY],
+        method: request.request_method,
+        path: request.path,
+        status: response.status,
+        duration_ms: ((Time.now - @started_at) * 1000).round
+      )
+    end
 
     def build_health_check
       config = Config.current

--- a/lib/cgminer_monitor/openapi.yml
+++ b/lib/cgminer_monitor/openapi.yml
@@ -21,6 +21,9 @@ paths:
       responses:
         "200":
           description: Healthy or starting
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
           content:
             application/json:
               schema:
@@ -35,6 +38,9 @@ paths:
                   uptime_s: { type: integer }
         "503":
           description: Degraded
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
 
   /v2/metrics:
     get:
@@ -45,6 +51,9 @@ paths:
       responses:
         "200":
           description: Prometheus text exposition
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
           content:
             text/plain:
               schema:
@@ -59,6 +68,9 @@ paths:
       responses:
         "200":
           description: Miner list
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
           content:
             application/json:
               schema:
@@ -89,12 +101,18 @@ paths:
       responses:
         "200":
           description: Device snapshot
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/SnapshotEnvelope"
         "404":
           description: Unknown miner
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
 
   /v2/miners/{miner}/pools:
     get:
@@ -109,12 +127,18 @@ paths:
       responses:
         "200":
           description: Pool snapshot
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/SnapshotEnvelope"
         "404":
           description: Unknown miner
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
 
   /v2/miners/{miner}/summary:
     get:
@@ -129,12 +153,18 @@ paths:
       responses:
         "200":
           description: Summary snapshot
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/SnapshotEnvelope"
         "404":
           description: Unknown miner
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
 
   /v2/miners/{miner}/stats:
     get:
@@ -149,12 +179,18 @@ paths:
       responses:
         "200":
           description: Stats snapshot
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/SnapshotEnvelope"
         "404":
           description: Unknown miner
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
 
   /v2/graph_data/hashrate:
     get:
@@ -178,12 +214,18 @@ paths:
       responses:
         "200":
           description: Hashrate data
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/GraphDataEnvelope"
         "400":
           description: Invalid parameters
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
 
   /v2/graph_data/temperature:
     get:
@@ -206,12 +248,18 @@ paths:
       responses:
         "200":
           description: Temperature data
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/GraphDataEnvelope"
         "400":
           description: Invalid parameters
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
 
   /v2/graph_data/availability:
     get:
@@ -234,12 +282,18 @@ paths:
       responses:
         "200":
           description: Availability data
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/GraphDataEnvelope"
         "400":
           description: Invalid parameters
+          headers:
+            X-Cgminer-Request-Id:
+              $ref: '#/components/headers/XCgminerRequestId'
 
   /openapi.yml:
     get:

--- a/spec/cgminer_monitor/http_app_spec.rb
+++ b/spec/cgminer_monitor/http_app_spec.rb
@@ -91,6 +91,37 @@ RSpec.describe CgminerMonitor::HttpApp do
       get '/v2/healthz'
       expect(last_response.headers['X-Cgminer-Request-Id']).to eq('echo-trace-003')
     end
+
+    it 'echoes a freshly generated UUID in the response header when no inbound header' do
+      # Pins the path Prometheus scrapers + direct curls hit. A regression
+      # that breaks generated-UUID echo would silently break Phase 3's
+      # "we got back the same request_id we sent" verification.
+      get '/v2/healthz'
+      expect(last_response.headers['X-Cgminer-Request-Id']).to match(/\A[0-9a-f-]{36}\z/)
+    end
+
+    it 'echoes the request_id in the response header on the 500 error path' do
+      allow_any_instance_of(described_class).to receive(:configured_miners)
+        .and_raise(StandardError, 'boom')
+      header 'X-Cgminer-Request-Id', 'crash-echo-trace'
+      get '/v2/miners'
+      expect(last_response.status).to eq(500)
+      expect(last_response.headers['X-Cgminer-Request-Id']).to eq('crash-echo-trace')
+    end
+
+    it 'emits http.request with status 500 on the error path (matches cgminer_manager)' do
+      # Sinatra skips after-filters when error fires; without explicit
+      # emission from the error block, dashboards counting requests via
+      # http.request would undercount errors.
+      allow_any_instance_of(described_class).to receive(:configured_miners)
+        .and_raise(StandardError, 'boom')
+      header 'X-Cgminer-Request-Id', 'crash-request-trace'
+      get '/v2/miners'
+      request_event = captured.find { |e| e[:event] == 'http.request' }
+      expect(request_event).not_to be_nil
+      expect(request_event[:request_id]).to eq('crash-request-trace')
+      expect(request_event[:status]).to eq(500)
+    end
   end
 
   describe 'fail-loud guard on unconfigured HttpApp' do


### PR DESCRIPTION
Fast-follow on PR #19 absorbing six findings from a staff review of v1.3.0:

1. **Sinatra skips after-filters when error fires.** \`http.request\` was never emitted on the 500 path — dashboards counting requests via this event would undercount errors. Extract a \`log_http_request\` helper called from both the success after-filter and the error block. Mirrors \`cgminer_manager\`'s existing \`http.request\` behavior on the same crash path.

2. **Drop the \`@request_id\` ivar.** The \`before\`-filter populated it but the \`error\` block already read \`env[RequestId::ENV_KEY]\` directly. Asymmetric. Now both paths read env, single source of truth.

3. **Wire \`$ref\` to \`components.headers.XCgminerRequestId\`.** Defined in PR #19 but never referenced — SDK generators wouldn't surface the response-header echo to clients. Now wired to every response (200/404/400/503) across all 10 \`/v2/*\` operations.

4-5. **Test gaps.** Assert echo on the generated-UUID path (no inbound header) and on the 500 error path; assert \`http.request\` emits with status 500 on crash.

6. **\`request.path_info\` → \`request.path\`.** Match \`docs/log_schema.md\`'s standard-keys table which says \`path\` is \`request.path\`.

## Test plan

- [x] \`bundle exec rake\` clean (48 files, no rubocop offenses)
- [x] 265 → 268 examples, 0 failures
- [x] OpenAPI parity check still green
- [x] Backward compatible — existing log consumers unaffected (\`http.request\` is additive on the error path; the 200 path's event shape is unchanged)