### PR TITLE
v1.3.1: widen cgminer_api_client constraint to allow v0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] — 2026-04-25
+
+### Changed
+- **Widened `cgminer_api_client` constraint** from `~> 0.3.0` to
+  `>= 0.3, < 0.5` so consumers like `cgminer_manager` v1.6.0 (which
+  requires api_client v0.4.0 for the `on_wire:` kwarg) can pin both
+  monitor and api_client without a Bundler conflict. No code change.
+
 ### Added
 - **Trace-id propagation** via `X-Cgminer-Request-Id` HTTP header.
   New `CgminerMonitor::RequestId` Rack middleware extracts the

--- a/cgminer_monitor.gemspec
+++ b/cgminer_monitor.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ["cgminer_monitor"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "cgminer_api_client", "~> 0.3.0"
+  spec.add_dependency "cgminer_api_client", ">= 0.3", "< 0.5"
   spec.add_dependency "mongoid",            "~> 9.0"
   spec.add_dependency "puma",               ">= 6.0"
   spec.add_dependency "rack-cors",          "~> 2.0"

--- a/lib/cgminer_monitor/version.rb
+++ b/lib/cgminer_monitor/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CgminerMonitor
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 
   def self.version
     VERSION


### PR DESCRIPTION
Pure constraint change. cgminer_manager v1.6.0 (upcoming trace-id propagation release) requires cgminer_api_client v0.4.0 for the on_wire: kwarg on Miner#initialize, but cgminer_monitor's gemspec previously pinned `~> 0.3.0`, which excluded v0.4 and caused a Bundler conflict in any downstream that pinned both monitor and api_client.

Widened to `>= 0.3, < 0.5` so both 0.3.x and 0.4.x resolve. No code change in monitor — the on_wire: kwarg is only consumed by manager through closure-based wiring in FleetBuilders.

## Test plan

- [x] bundle exec rake clean (48 files, no rubocop offenses)
- [x] 268 examples, 0 failures
- [x] No code changes; this is purely a gemspec constraint widening + version bump for downstream Bundler resolution