### PR TITLE
v1.3.2: fix Dockerfile for Bundler 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] — 2026-04-25
+
+### Fixed
+- **`Dockerfile`** — replaced removed-in-Bundler-4 `bundle binstubs
+  --path /usr/local/bundle/bin` with `bundle config set --local bin`
+  + plain `bundle binstubs --force`. Was silently OK on Bundler 2.x
+  (which deprecated but accepted `--path`); fails loudly on Bundler
+  4.x (which removes it). The `ruby:4.0-slim` base image ships
+  Bundler 4.x, so the Docker build was broken at HEAD. Surfaced by
+  `cgminer_manager`'s e2e workflow when it bumped its `monitor_ref`
+  pin from `master` (v1.2.0) to `v1.3.1` for trace-id propagation
+  assertions.
+
 ## [1.3.1] — 2026-04-25
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ COPY Gemfile cgminer_monitor.gemspec ./
 COPY lib/cgminer_monitor/version.rb lib/cgminer_monitor/version.rb
 
 RUN bundle config set --local without 'development' && \
+    bundle config set --local bin /usr/local/bundle/bin && \
     bundle install --jobs 4 && \
-    bundle binstubs cgminer_monitor --force --path /usr/local/bundle/bin
+    bundle binstubs cgminer_monitor --force
 
 COPY . .
 

--- a/lib/cgminer_monitor/version.rb
+++ b/lib/cgminer_monitor/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CgminerMonitor
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 
   def self.version
     VERSION


### PR DESCRIPTION
## Summary

`bundle binstubs --path` was deprecated in Bundler 2.x and removed in Bundler 4.x. `ruby:4.0-slim` ships Bundler 4.x, so the Docker build is broken at HEAD — silently OK on local dev (Bundler 2.x) but failing in CI / docker-compose builds.

Replaced with the recommended Bundler 4.x form:

```
bundle config set --local bin /usr/local/bundle/bin
bundle binstubs cgminer_monitor --force
```

## How surfaced

`cgminer_manager` v1.6.0 trace-id propagation work bumped its e2e workflow's `monitor_ref` pin from `master` (v1.2.0) to `v1.3.1` so the trace-id assertions could test against monitor's new RequestId middleware. The v1.3.1 Dockerfile inherited the same broken `--path` flag from earlier history; the e2e build broke at the monitor builder stage. Two e2e runs (24936102386, 24936325886) failed on this before the issue was tracked down.

## Test plan

- [x] `bundle exec rake` clean (48 files, no rubocop offenses)
- [x] 268 examples, 0 failures
- [x] No Ruby code change; pure Dockerfile + version + CHANGELOG