### PR TITLE
Emit code symbol on poll.miner_failed for log-side dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.3] — 2026-04-25
+
+### Added
+- **`code` field on `poll.miner_failed`** — symbolic error tag for
+  log-side dispatch, populated from `cgminer_api_client::ApiError#code`
+  (v0.4.0+) for wire-side errors (e.g. `:access_denied`,
+  `:invalid_command`, `:unknown`) and synthesized at the rescue site
+  for transport-layer errors (`:timeout`, `:connection_error`) and
+  any unmapped exception (`:unexpected`). Six-symbol vocabulary
+  documented in `docs/log_schema.md`'s Standard-keys table. Operators
+  can now `jq 'select(.code == "access_denied")'` against monitor
+  logs instead of grep-ing English error message substrings.
+
 ### Changed
 - **`docs/log_schema.md`** gains a `code` standard key documenting the
   six-symbol vocabulary that consumers (`cgminer_monitor`,
@@ -15,9 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `invalid_command`, `unknown`, `timeout`, `connection_error`,
   `unexpected`. `poll.miner_failed` gains `code` as an optional
   field; `admin.result` gains `failed_codes` as an optional
-  count-by-code map (e.g. `{"access_denied": 3}`). Implementations
-  follow in upcoming `cgminer_monitor` and `cgminer_manager`
-  releases — schema is a forward-looking contract until then.
+  count-by-code map (e.g. `{"access_denied": 3}`). The
+  `admin.result` field will be populated by an upcoming
+  `cgminer_manager` release; in this gem, only `poll.miner_failed`
+  emits the new field.
 
 ## [1.3.2] — 2026-04-25
 

--- a/lib/cgminer_monitor/poller.rb
+++ b/lib/cgminer_monitor/poller.rb
@@ -154,7 +154,11 @@ module CgminerMonitor
         miner_id, command,
         { "fetched_at" => now, "ok" => false, "response" => nil, "error" => error_msg }
       )
-      Logger.warn(event: 'poll.miner_failed', miner: miner_id, command: command, error: error_msg)
+      Logger.warn(event: 'poll.miner_failed',
+                  miner: miner_id,
+                  command: command,
+                  error: error_msg,
+                  code: miner_result ? code_for(miner_result.error) : :unexpected)
     end
 
     def append_synthetic_samples(miner_id, miner_ok, elapsed_ms, now, all_samples)
@@ -256,6 +260,20 @@ module CgminerMonitor
       @mutex.synchronize do
         @cv.wait(@mutex, seconds) unless @stopped
       end
+    end
+
+    # Maps a rescued exception to a single-symbol vocabulary for
+    # log-side dispatch. cgminer_api_client::ApiError (v0.4.0+)
+    # carries its own #code Symbol; transport-layer errors don't,
+    # so synthesize a parallel symbol so consumers can `case .code`
+    # uniformly. The six values match docs/log_schema.md's `code`
+    # standard-key entry.
+    def code_for(error)
+      return error.code if error.respond_to?(:code) && error.code.is_a?(Symbol)
+      return :timeout if error.is_a?(CgminerApiClient::TimeoutError)
+      return :connection_error if error.is_a?(CgminerApiClient::ConnectionError)
+
+      :unexpected
     end
   end
 end

--- a/lib/cgminer_monitor/version.rb
+++ b/lib/cgminer_monitor/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CgminerMonitor
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 
   def self.version
     VERSION

--- a/spec/cgminer_monitor/poller_spec.rb
+++ b/spec/cgminer_monitor/poller_spec.rb
@@ -314,6 +314,79 @@ RSpec.describe CgminerMonitor::Poller do
     it 'does not raise — the loop continues' do
       expect { poller.poll_once }.not_to raise_error
     end
+
+    it 'emits code: from ApiError#code on poll.miner_failed (api errors carry a wire code)' do
+      events = []
+      allow(CgminerMonitor::Logger).to receive(:warn) { |entry| events << entry }
+      api_error = CgminerApiClient::ApiError.new('45: Access denied', cgminer_code: 45)
+      api_failure = CgminerApiClient::MinerResult.failure(miner, api_error)
+      %w[summary devs pools stats].each do |cmd|
+        allow(miner_pool).to receive(:query).with(cmd)
+                                            .and_return(CgminerApiClient::PoolResult.new([api_failure]))
+      end
+
+      poller.poll_once
+
+      failed = events.find { |e| e[:event] == 'poll.miner_failed' }
+      expect(failed[:code]).to eq(:access_denied)
+    end
+
+    it 'synthesizes :timeout for TimeoutError on poll.miner_failed (no wire code available)' do
+      events = []
+      allow(CgminerMonitor::Logger).to receive(:warn) { |entry| events << entry }
+      timeout = CgminerApiClient::TimeoutError.new('connect timeout')
+      timeout_failure = CgminerApiClient::MinerResult.failure(miner, timeout)
+      %w[summary devs pools stats].each do |cmd|
+        allow(miner_pool).to receive(:query).with(cmd)
+                                            .and_return(CgminerApiClient::PoolResult.new([timeout_failure]))
+      end
+
+      poller.poll_once
+
+      failed = events.find { |e| e[:event] == 'poll.miner_failed' }
+      expect(failed[:code]).to eq(:timeout)
+    end
+
+    it 'synthesizes :connection_error for ConnectionError on poll.miner_failed' do
+      events = []
+      allow(CgminerMonitor::Logger).to receive(:warn) { |entry| events << entry }
+      poller.poll_once
+
+      failed = events.find { |e| e[:event] == 'poll.miner_failed' }
+      expect(failed[:code]).to eq(:connection_error)
+    end
+
+    it 'emits :access_denied directly from AccessDeniedError subclass (not just base ApiError)' do
+      events = []
+      allow(CgminerMonitor::Logger).to receive(:warn) { |entry| events << entry }
+      access_denied = CgminerApiClient::AccessDeniedError.new('45: Access denied', cgminer_code: 45)
+      ad_failure = CgminerApiClient::MinerResult.failure(miner, access_denied)
+      %w[summary devs pools stats].each do |cmd|
+        allow(miner_pool).to receive(:query).with(cmd)
+                                            .and_return(CgminerApiClient::PoolResult.new([ad_failure]))
+      end
+
+      poller.poll_once
+
+      failed = events.find { |e| e[:event] == 'poll.miner_failed' }
+      expect(failed[:code]).to eq(:access_denied)
+    end
+
+    it 'falls through to :unexpected for any non-CgminerApiClient StandardError' do
+      events = []
+      allow(CgminerMonitor::Logger).to receive(:warn) { |entry| events << entry }
+      stray = StandardError.new('out of left field')
+      stray_failure = CgminerApiClient::MinerResult.failure(miner, stray)
+      %w[summary devs pools stats].each do |cmd|
+        allow(miner_pool).to receive(:query).with(cmd)
+                                            .and_return(CgminerApiClient::PoolResult.new([stray_failure]))
+      end
+
+      poller.poll_once
+
+      failed = events.find { |e| e[:event] == 'poll.miner_failed' }
+      expect(failed[:code]).to eq(:unexpected)
+    end
   end
 
   describe '#stop' do


### PR DESCRIPTION
## Summary

Adds a structured `code` field on the `poll.miner_failed` log event so operators can dispatch on a single-symbol vocabulary instead of grepping English error message substrings:

```bash
jq 'select(.code == "access_denied")'   # was: grep -i "access denied"
```

Six values, mapped from the rescued exception via a new private `Poller#code_for(error)` helper:

| code | Source |
|---|---|
| `:access_denied` / `:invalid_command` / `:unknown` | `cgminer_api_client::ApiError#code` (v0.4.0+) |
| `:timeout` | synthesized for `CgminerApiClient::TimeoutError` |
| `:connection_error` | synthesized for `CgminerApiClient::ConnectionError` |
| `:unexpected` | defensive fallback; should not occur in practice |

The Mongo persistence path (snapshot upsert via `snapshot_ops << build_snapshot_upsert(...)`) is unchanged — only the `Logger.warn` call gained the new field.

Bumps to v1.3.3.

> Re-targets develop. The original PR (#24) was inadvertently merged to `master`; this re-applies the same diff against `develop` so the develop history stays linear with the schema-doc PR (#23).

## Test plan

- [x] `bundle exec rake` — 273 examples / 0 failures, RuboCop clean
- [x] New specs in `spec/cgminer_monitor/poller_spec.rb` cover all five code values: `ApiError`, `AccessDeniedError` subclass, `TimeoutError`, `ConnectionError`, generic `StandardError` (`:unexpected` fallback)
- [ ] CI green on full Mongo matrix