### PR TITLE
Add composite alert rules (AND-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] — 2026-04-25
+
+### Added
+- **Composite alert rules** — combine multiple atomic-metric clauses
+  into a single named rule with **AND** semantics so a correlated
+  fault (e.g. low hashrate + high temperature = thermal-stressed
+  rig) fires one alert instead of two. Configure one composite per
+  ENV var:
+
+  ```bash
+  CGMINER_MONITOR_ALERTS_COMPOSITE_THERMAL_STRESS='ghs_5s<500 & temp_max>80'
+  ```
+
+  Grammar is deliberately tiny: `<metric> <op> <number>` clauses
+  joined by `&`, with allowed metrics `ghs_5s` / `temp_max` /
+  `offline_seconds` and allowed operators `<` / `>` / `<=` / `>=` /
+  `==`. At least 2 clauses required (single-clause composites
+  duplicate built-in rules). OR (`|`) is explicitly out of scope
+  for v1.4.0 and triggers a specific boot-time error.
+
+  Composites reuse the existing fired/resolved/cooldown lifecycle
+  and webhook sink. Boot validation aggregates every clause-level
+  problem and prefixes the originating ENV var name so the operator
+  knows which composite is broken without grepping.
+
+  A composite is **skipped** for the tick if any required atom
+  reading is missing (no relevant snapshot, restart-window
+  suppression on `offline_seconds`, etc.) — no state write, no
+  fire, no resolve. Protects against transient bad data silently
+  transitioning a real violating composite to `ok`. AND-resolution
+  semantic: composite resolves as soon as any clause stops
+  violating. Built-in + composite double-fire on the same
+  observation is intentional (operator opted into both).
+
+- **`code` field on `poll.miner_failed`** continues unchanged from
+  v1.3.3.
+
+### Changed
+- **`alert.fired` / `alert.resolved` event shape** extended with an
+  optional `details` field (composite rules only — structured
+  per-clause snapshot including the canonical expression). Built-in
+  rules' wire shape is unchanged. Top-level `threshold` and
+  `observed` become Strings for composite-rule events (e.g.
+  `"ghs_5s<500.0 & temp_max>80.0"` and
+  `"ghs_5s=450.0 temp_max=82.3"`); `unit` is `null` for composites
+  (the formatted strings already carry the per-metric context).
+- **Slack / Discord webhook formatters** elide the `unit` separator
+  when `unit:` is `nil` so composites render cleanly without
+  trailing or double spaces. Existing built-in renderings
+  (`"450.0 GH/s"` etc.) are unchanged. `slack_title` falls back to
+  `"Composite alert: <rule>"` for any rule not in the built-in
+  `RULE_TITLES` map.
+- **`alerts_enabled=true` boot validation** now accepts a config
+  with composite rules and no per-threshold ENV vars (previously
+  required at least one of the three threshold env vars; now
+  requires at least one of {threshold OR composite}).
+- **`docs/log_schema.md`** updated: `rule` standard key documents
+  the composite rule-name space; `threshold` / `observed` document
+  the String-for-composites shape; new `details` / `built_in_rules`
+  / `composite_rules` standard keys reserved; `alert.fired` /
+  `alert.resolved` / `alert.config_loaded` /
+  `alert.suppressed_during_restart_window` event-catalog rows
+  updated.
+- **New `alert.config_loaded` log line** emitted at AlertEvaluator
+  construction listing enabled built-in rules and composite rule
+  names — operator can confirm at boot that ENV parsed as intended.
+
 ## [1.3.3] — 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Opt-in per-miner threshold alerts. Disabled by default — leave `ALERTS_ENABLED
 | `CGMINER_MONITOR_ALERTS_COOLDOWN_SECONDS` | `300` | Minimum time between re-fires of the same `(miner, rule)` while it stays violating. |
 | `CGMINER_MONITOR_ALERTS_WEBHOOK_TIMEOUT_SECONDS` | `2` | Per-POST open+read timeout. One attempt, no retry. Failures log `event=alert.webhook_failed` and do not abort the poll loop. |
 
-At least one of the three rule thresholds must be set when `ALERTS_ENABLED=true` — the service refuses to boot otherwise. A Slack example:
+At least one of the three built-in rule thresholds OR at least one composite rule (see below) must be configured when `ALERTS_ENABLED=true` — the service refuses to boot otherwise. A Slack example:
 
 ```bash
 export CGMINER_MONITOR_ALERTS_ENABLED=true
@@ -82,6 +82,48 @@ export CGMINER_MONITOR_ALERTS_OFFLINE_AFTER_SECONDS=600
 ```
 
 See [`docs/log_schema.md`](docs/log_schema.md) for the `alert.*` event catalog and the generic webhook body shape.
+
+#### Composite alert rules (v1.4.0+)
+
+Combine multiple atomic-metric clauses into a single named rule with **AND** semantics — useful when a correlated fault (e.g. low hashrate + high temperature = thermal-stressed rig) would otherwise trip two built-in rules and double-page the operator. Configure one composite per ENV var; the suffix is the rule name (lowercased).
+
+```bash
+export CGMINER_MONITOR_ALERTS_COMPOSITE_THERMAL_STRESS='ghs_5s<500 & temp_max>80'
+export CGMINER_MONITOR_ALERTS_COMPOSITE_COLD_DEAD='ghs_5s<100 & temp_max<30'
+```
+
+**Atom-name vs built-in-rule-name table** — composite expressions reference the underlying *atom* (a measurement), not the *rule* (an evaluation):
+
+| Atom (used in composite expression) | Built-in rule (used in ENV var name) | Snapshot source |
+|---|---|---|
+| `ghs_5s` | `hashrate_below` | `summary` snapshot, `SUMMARY[0].GHS 5s` |
+| `temp_max` | `temperature_above` | `devs` snapshot, max over `DEVS[].Temperature` |
+| `offline_seconds` | `offline` | `Sample` time-series, seconds since last `poll/ok` |
+
+Typing `temperature_above>80` in a composite expression is a parse error — use `temp_max>80`.
+
+**Grammar:**
+
+```
+<expr>   := <clause> ('&' <clause>)+    # at least 2 clauses
+<clause> := <metric> <op> <number>
+<metric> := one of {ghs_5s, temp_max, offline_seconds}
+<op>     := one of {<, >, <=, >=, ==}   # multi-character ops are matched longest-first (`<=` before `<`)
+<number> := decimal (sign + integer + optional fractional)
+```
+
+Whitespace around `&` and operators is tolerated. **OR is not yet supported** — `|` triggers a specific boot-time error. Single-clause composites are also rejected (use the built-in rule instead).
+
+A malformed composite fails fast at startup with a `ConfigError` that prefixes the originating ENV var name (e.g. `CGMINER_MONITOR_ALERTS_COMPOSITE_THERMAL_STRESS: unknown metric 'foo'…`) — not at first violation, hours after boot.
+
+**Gotchas:**
+
+- **Flap behavior on noisy correlated metrics.** Cooldown debounces *fires* (re-fire requires `ALERTS_COOLDOWN_SECONDS` since the last fire), but *resolves* emit immediately on transition. A composite whose clauses oscillate around their thresholds can fire→resolve→fire within one cooldown window. Use stable thresholds (margin away from the operating point) and keep the metric noise floor in mind. A per-resolve debounce knob may land in a future release; for now, prefer stable thresholds.
+- **Built-in + composite double-fire by design.** If `ALERTS_TEMPERATURE_MAX_C=80` AND a composite uses `temp_max>80`, both rules fire on the same observation — the operator opted into both. Disable the built-in if you only want the composite.
+- **Missing snapshots → composite skipped.** If a required atom reading is unavailable (no `devs` snapshot yet, restart-window suppression on `offline_seconds`, etc.), the composite is skipped for that miner that tick. **No state write, no fire, no resolve** — protects against transient bad data silently transitioning a real violating composite to ok.
+- **Composite name reservations.** A composite cannot be named `hashrate_below`, `temperature_above`, or `offline` (collides with a built-in rule). Boot fails loud.
+
+The webhook payload's top-level `threshold` and `observed` fields become strings for composites (e.g. `"ghs_5s<500.0 & temp_max>80.0"` and `"ghs_5s=450.0 temp_max=82.3"`); a new optional `details` hash carries the structured per-clause snapshot for generic-format consumers. Slack and Discord renderers display the strings unchanged. See [`docs/log_schema.md`](docs/log_schema.md) for the full event-catalog updates.
 
 ### Miners file
 

--- a/docs/log_schema.md
+++ b/docs/log_schema.md
@@ -62,10 +62,13 @@ Keys that appear across multiple events are named consistently. When you add a n
 | `retry_after`     | integer          | `42`                                        | seconds; paired with 429 responses |
 | `miner`           | string           | `"10.0.0.5:4028"`                           | scalar rig identifier — `"host:port"` |
 | `miners`          | integer          | `3`                                         | count of miners (or an array where the emit site documents it). Never a single rig |
-| `rule`            | string           | `"hashrate_below"`                          | alert rule name; one of `hashrate_below`, `temperature_above`, `offline` |
-| `threshold`       | number           | `1000.0`                                    | snapshot of the configured threshold at emit time (alert events only) |
-| `observed`        | number           | `732.5`                                     | the observed value that triggered a fire/resolve (alert events only) |
-| `unit`            | string           | `"GH/s"`                                    | unit for `threshold`/`observed` — `"GH/s"`, `"C"`, or `"seconds"` |
+| `rule`            | string           | `"hashrate_below"`                          | alert rule name. Built-in rules: `hashrate_below`, `temperature_above`, `offline`. For composite rules (v1.4.0+), the value is the operator-defined composite name (e.g. `thermal_stress`). |
+| `threshold`       | number or string | `1000.0`                                    | snapshot of the configured threshold at emit time (alert events only). String for composite rules (e.g. `"ghs_5s<500.0 & temp_max>80.0"`); number for built-in rules. |
+| `observed`        | number or string | `732.5`                                     | the observed value that triggered a fire/resolve (alert events only). String for composite rules (e.g. `"ghs_5s=450.0 temp_max=82.0"`); number for built-in rules. |
+| `unit`            | string or null   | `"GH/s"`                                    | unit for `threshold`/`observed` — `"GH/s"`, `"C"`, or `"seconds"` for built-ins. `null` for composite rules (the threshold/observed strings already carry the per-metric context). |
+| `details`         | hash             | `{"expression":"…","clauses":{…}}`          | composite-rule structured payload (alert events only). Includes the canonical `expression` string and a per-`clauses` map of `{observed, threshold, op}` entries. Absent for built-in rules. |
+| `built_in_rules`  | array of strings | `["temperature_above"]`                     | enabled built-in rule names (`alert.config_loaded` only) |
+| `composite_rules` | array of strings | `["thermal_stress"]`                        | enabled composite rule names (`alert.config_loaded` only) |
 | `log_format`      | string           | `"json"` or `"text"`                        | effective formatter — `server.start` only |
 | `log_level`       | string           | `"info"`                                    | effective level threshold — `server.start` only |
 | `mongo_url`       | string           | `"mongodb://[REDACTED]@db:27017/monitor"`   | always credential-redacted; `server.start` only |
@@ -154,15 +157,17 @@ Manager's per-command wire telemetry, emitted at debug level (opt-in via `LOG_LE
 ### `alert.*` (cgminer_monitor)
 
 
-Opt-in per-miner threshold alerts. Wire-up: `CGMINER_MONITOR_ALERTS_ENABLED=true` plus a webhook URL and at least one of the three rule thresholds (`ALERTS_HASHRATE_MIN_GHS`, `ALERTS_TEMPERATURE_MAX_C`, `ALERTS_OFFLINE_AFTER_SECONDS`). See the repo README for the full env matrix.
+Opt-in per-miner threshold alerts. Wire-up: `CGMINER_MONITOR_ALERTS_ENABLED=true` plus a webhook URL and at least one of the three built-in rule thresholds (`ALERTS_HASHRATE_MIN_GHS`, `ALERTS_TEMPERATURE_MAX_C`, `ALERTS_OFFLINE_AFTER_SECONDS`) OR at least one composite rule (`CGMINER_MONITOR_ALERTS_COMPOSITE_*`, v1.4.0+). See the repo README for the full env matrix and composite-rule grammar.
 
 | Event | Level | Emitter | Required keys | Optional |
 |-------|-------|---------|---------------|----------|
-| `alert.fired` | warn | `AlertEvaluator` | `miner`, `rule`, `threshold`, `observed`, `unit` | |
-| `alert.resolved` | info | `AlertEvaluator` | `miner`, `rule`, `threshold`, `observed`, `unit` | |
+| `alert.fired` | warn | `AlertEvaluator` | `miner`, `rule`, `threshold`, `observed`, `unit` | `details` (composite rules only — structured per-clause snapshot, see `details` standard-key) |
+| `alert.resolved` | info | `AlertEvaluator` | `miner`, `rule`, `threshold`, `observed`, `unit` | `details` (composite rules only) |
+| `alert.config_loaded` | info | `AlertEvaluator` (one per construction) | `built_in_rules`, `composite_rules` | |
 | `alert.evaluation_complete` | info | `AlertEvaluator` (one per poll tick) | `duration_ms`, `rules_evaluated`, `fired_count`, `resolved_count` | |
 | `alert.evaluator_error` | error | `Poller` (catches the evaluator) | `error`, `message`, `backtrace` | |
 | `alert.state_write_failed` | error | `AlertEvaluator` | `miner`, `rule`, `error`, `message` | |
+| `alert.suppressed_during_restart_window` | info | `AlertEvaluator` (offline rule + composites using offline_seconds) | `miner`, `rule` | |
 | `alert.webhook_failed` | warn | `WebhookClient` | `miner`, `rule`, `error`, `message` | `status` (HTTP code on non-2xx responses) |
 
 ### `healthz.*` (cgminer_monitor)

--- a/lib/cgminer_monitor.rb
+++ b/lib/cgminer_monitor.rb
@@ -4,6 +4,8 @@ require 'cgminer_api_client'
 require 'mongoid'
 
 require 'cgminer_monitor/errors'
+require 'cgminer_monitor/composite_rule'
+require 'cgminer_monitor/composite_rule_parser'
 require 'cgminer_monitor/config'
 require 'cgminer_monitor/logger'
 require 'cgminer_monitor/sample'

--- a/lib/cgminer_monitor/alert_evaluator.rb
+++ b/lib/cgminer_monitor/alert_evaluator.rb
@@ -11,11 +11,19 @@ module CgminerMonitor
     UNITS = { 'hashrate_below' => 'GH/s',
               'temperature_above' => 'C',
               'offline' => 'seconds' }.freeze
+    # Maps each built-in rule name to the atom-keyed reading it consumes.
+    # Composites read the same atoms directly via their #required_metrics.
+    RULE_TO_ATOM = { 'hashrate_below' => 'ghs_5s',
+                     'temperature_above' => 'temp_max',
+                     'offline' => 'offline_seconds' }.freeze
+    private_constant :RULE_TO_ATOM
 
     def initialize(config, webhook_client: nil, restart_schedule_client: nil)
       @config                  = config
       @webhook_client          = webhook_client || default_webhook_client(config)
       @restart_schedule_client = restart_schedule_client
+
+      log_config_loaded if @config.alerts_enabled
     end
 
     def evaluate(now)
@@ -23,15 +31,22 @@ module CgminerMonitor
 
       started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       counts     = { fired: 0, resolved: 0, rules_evaluated: 0 }
+      readings_by_miner = miner_states(now)
 
-      miner_states(now).each do |miner, rule_readings|
-        rule_readings.each do |rule, observed|
-          next if observed.nil? # rule disabled or data unavailable
+      readings_by_miner.each do |miner, atom_readings|
+        RULES.each do |rule|
+          next if threshold_for(rule).nil? # built-in rule disabled
+
+          observed = atom_readings[RULE_TO_ATOM[rule]]
+          next if observed.nil? # data unavailable / suppressed
 
           counts[:rules_evaluated] += 1
-          evaluate_rule(miner: miner, rule: rule, observed: observed, now: now, counts: counts)
+          evaluate_built_in_rule(miner: miner, rule: rule, observed: observed,
+                                 now: now, counts: counts)
         end
       end
+
+      evaluate_composites(readings_by_miner, now, counts)
 
       Logger.info(event: 'alert.evaluation_complete',
                   duration_ms: ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1000).round(1),
@@ -42,26 +57,76 @@ module CgminerMonitor
 
     private
 
-    def evaluate_rule(miner:, rule:, observed:, now:, counts:)
-      threshold = threshold_for(rule)
-      return if threshold.nil?
+    # Boot-time observability: one log line per AlertEvaluator instance
+    # listing exactly which rules will run. Lets the operator confirm
+    # at startup that their ENV parsed the way they intended.
+    def log_config_loaded
+      enabled_built_ins = RULES.reject { |r| threshold_for(r).nil? }
+      Logger.info(event: 'alert.config_loaded',
+                  built_in_rules: enabled_built_ins,
+                  composite_rules: @config.composite_rules.map(&:name))
+    end
 
+    def evaluate_built_in_rule(miner:, rule:, observed:, now:, counts:)
+      threshold = threshold_for(rule)
       violating = violates?(rule, observed, threshold)
       state_doc = AlertState.where(_id: AlertState.composite_id(miner, rule)).first
+      common = { miner: miner, rule: rule, observed: observed, threshold: threshold,
+                 unit: UNITS[rule], now: now, state_doc: state_doc }
 
       if violating
-        handle_violating(miner: miner, rule: rule, observed: observed,
-                         threshold: threshold, state_doc: state_doc, now: now, counts: counts)
+        handle_violating(**common, counts: counts)
       elsif state_doc&.state == 'violating'
-        handle_resolved(miner: miner, rule: rule, observed: observed,
-                        threshold: threshold, state_doc: state_doc, now: now, counts: counts)
+        handle_resolved(**common, counts: counts)
       else
-        ensure_ok_state(miner: miner, rule: rule, observed: observed,
-                        threshold: threshold, state_doc: state_doc, now: now)
+        ensure_ok_state(**common)
       end
     end
 
-    def handle_violating(miner:, rule:, observed:, threshold:, state_doc:, now:, counts:)
+    # Composites iterate the SAME state-transition machinery as built-in
+    # rules but pass string-typed threshold/observed and the structured
+    # details: payload. Crucially: a composite that can't be evaluated
+    # this tick (any required atom reading is nil) is SKIPPED — no state
+    # write, no fire/resolve. This protects against transient bad
+    # snapshots silently transitioning a real violating composite to ok.
+    def evaluate_composites(readings_by_miner, now, counts)
+      return if @config.composite_rules.empty?
+
+      readings_by_miner.each do |miner, atom_readings|
+        @config.composite_rules.each do |composite|
+          next unless composite.evaluable?(atom_readings)
+
+          counts[:rules_evaluated] += 1
+          evaluate_composite_rule(composite: composite, miner: miner,
+                                  readings: atom_readings, now: now, counts: counts)
+        end
+      end
+    end
+
+    def evaluate_composite_rule(composite:, miner:, readings:, now:, counts:)
+      violating = composite.violates?(readings)
+      state_doc = AlertState.where(_id: AlertState.composite_id(miner, composite.name)).first
+      common = {
+        miner: miner, rule: composite.name,
+        observed: composite.payload_observed(readings),
+        threshold: composite.payload_threshold,
+        unit: nil, now: now, state_doc: state_doc,
+        # Composites carry per-clause structure on the wire AND in state.
+        details: composite.payload_details(readings),
+        last_observed_components: composite.payload_details(readings)['clauses']
+      }
+
+      if violating
+        handle_violating(**common, counts: counts)
+      elsif state_doc&.state == 'violating'
+        handle_resolved(**common, counts: counts)
+      else
+        ensure_ok_state(**common)
+      end
+    end
+
+    def handle_violating(miner:, rule:, observed:, threshold:, unit:, state_doc:, now:, counts:,
+                         details: nil, last_observed_components: nil)
       was_violating = state_doc&.state == 'violating'
       cooldown_elapsed = was_violating && state_doc.last_fired_at &&
                          (now - state_doc.last_fired_at) >= @config.alerts_cooldown_seconds
@@ -69,6 +134,7 @@ module CgminerMonitor
 
       upsert_state(miner: miner, rule: rule, observed: observed, threshold: threshold,
                    state: 'violating',
+                   last_observed_components: last_observed_components,
                    last_fired_at: fire ? now : state_doc&.last_fired_at,
                    last_transition_at: was_violating ? state_doc.last_transition_at : now)
 
@@ -76,33 +142,49 @@ module CgminerMonitor
 
       counts[:fired] += 1
       emit(event: 'alert.fired', level: :warn,
-           miner: miner, rule: rule, observed: observed, threshold: threshold, now: now)
+           miner: miner, rule: rule, observed: observed, threshold: threshold,
+           unit: unit, now: now, details: details)
     end
 
-    def handle_resolved(miner:, rule:, observed:, threshold:, state_doc:, now:, counts:)
+    def handle_resolved(miner:, rule:, observed:, threshold:, unit:, state_doc:, now:, counts:,
+                        details: nil, last_observed_components: nil)
       upsert_state(miner: miner, rule: rule, observed: observed, threshold: threshold,
                    state: 'ok',
+                   last_observed_components: last_observed_components,
                    last_fired_at: state_doc&.last_fired_at,
                    last_transition_at: now)
       counts[:resolved] += 1
       emit(event: 'alert.resolved', level: :info,
-           miner: miner, rule: rule, observed: observed, threshold: threshold, now: now)
+           miner: miner, rule: rule, observed: observed, threshold: threshold,
+           unit: unit, now: now, details: details)
     end
 
-    def ensure_ok_state(miner:, rule:, observed:, threshold:, state_doc:, now:)
+    def ensure_ok_state(miner:, rule:, observed:, threshold:, unit:, state_doc:, now:,
+                        details: nil, last_observed_components: nil)
+      _ = unit # not used in the ok path; accepted for keyword-symmetry with handle_*
+      _ = details
       return if state_doc&.state == 'ok' # no-op; avoid a Mongo write per tick
 
       upsert_state(miner: miner, rule: rule, observed: observed, threshold: threshold,
                    state: 'ok',
+                   last_observed_components: last_observed_components,
                    last_fired_at: nil,
                    last_transition_at: now)
     end
 
+    # `last_observed` is Float on AlertState; for composites we pass a
+    # String through `observed:` so the wire payload is human-readable,
+    # but we MUST NOT let that String reach the Float field (Mongoid
+    # would silently coerce it to 0.0). Built-in callers continue to
+    # pass a Float; composites store the per-clause hash in
+    # `last_observed_components` and nil-out `last_observed`.
     def upsert_state(miner:, rule:, observed:, threshold:, state:,
-                     last_fired_at:, last_transition_at:)
+                     last_fired_at:, last_transition_at:, last_observed_components: nil)
       doc = AlertState.find_or_initialize_by(_id: AlertState.composite_id(miner, rule))
       doc.assign_attributes(miner: miner, rule: rule, state: state,
-                            threshold: threshold, last_observed: observed,
+                            threshold: numeric_or_nil(threshold),
+                            last_observed: numeric_or_nil(observed),
+                            last_observed_components: last_observed_components,
                             last_fired_at: last_fired_at,
                             last_transition_at: last_transition_at)
       doc.save!
@@ -111,14 +193,21 @@ module CgminerMonitor
                    error: e.class.to_s, message: e.message)
     end
 
-    def emit(event:, level:, miner:, rule:, observed:, threshold:, now:)
-      Logger.public_send(level, event: event, miner: miner, rule: rule,
-                                threshold: threshold, observed: observed, unit: UNITS[rule])
+    def numeric_or_nil(value)
+      value.is_a?(Numeric) ? value : nil
+    end
+
+    def emit(event:, level:, miner:, rule:, observed:, threshold:, unit:, now:, details: nil)
+      log_payload = { event: event, miner: miner, rule: rule,
+                      threshold: threshold, observed: observed, unit: unit }
+      log_payload[:details] = details unless details.nil?
+      Logger.public_send(level, **log_payload)
+
       return unless @webhook_client
 
       @webhook_client.fire(event: event, miner: miner, rule: rule,
                            threshold: threshold, observed: observed,
-                           unit: UNITS[rule], fired_at: now)
+                           unit: unit, fired_at: now, details: details)
     end
 
     def threshold_for(rule)
@@ -137,26 +226,43 @@ module CgminerMonitor
       end
     end
 
-    # Returns {miner_id => {'hashrate_below' => val, 'temperature_above' => val, 'offline' => val}}.
-    # Each reading is nil when the rule is disabled or the data isn't available.
+    # Returns { miner_id => { 'ghs_5s' => val, 'temp_max' => val, 'offline_seconds' => val } }.
+    # Each atom is read whenever ANY rule (built-in OR composite) needs it,
+    # so disabling the built-in temperature_above rule but defining a
+    # composite that uses temp_max still pulls the devs snapshot. Atom is
+    # nil when no rule needs it OR when the underlying data is missing.
     def miner_states(now)
-      readings = Hash.new { |h, k| h[k] = { 'hashrate_below' => nil, 'temperature_above' => nil, 'offline' => nil } }
+      atom_readings = Hash.new { |h, k| h[k] = blank_atom_readings }
 
-      if @config.alerts_hashrate_min_ghs
+      if atom_required?('ghs_5s')
         Snapshot.where(command: 'summary', ok: true).each do |snap|
-          readings[snap.miner]['hashrate_below'] = extract_hashrate(snap)
+          atom_readings[snap.miner]['ghs_5s'] = extract_hashrate(snap)
         end
       end
 
-      if @config.alerts_temperature_max_c
+      if atom_required?('temp_max')
         Snapshot.where(command: 'devs', ok: true).each do |snap|
-          readings[snap.miner]['temperature_above'] = extract_temperature(snap)
+          atom_readings[snap.miner]['temp_max'] = extract_temperature(snap)
         end
       end
 
-      populate_offline_readings(readings, now) if @config.alerts_offline_after_seconds
+      populate_offline_readings(atom_readings, now) if atom_required?('offline_seconds')
 
-      readings
+      atom_readings
+    end
+
+    def blank_atom_readings
+      { 'ghs_5s' => nil, 'temp_max' => nil, 'offline_seconds' => nil }
+    end
+
+    # True when at least one rule (built-in or composite) consumes
+    # the atom — drives whether `miner_states` bothers reading the
+    # underlying snapshot/sample at all.
+    def atom_required?(atom)
+      built_in_rule = RULE_TO_ATOM.invert[atom]
+      return true if built_in_rule && !threshold_for(built_in_rule).nil?
+
+      @config.composite_rules.any? { |c| c.required_metrics.include?(atom) }
     end
 
     # Offline = seconds since the miner's last successful poll.
@@ -168,26 +274,30 @@ module CgminerMonitor
     # poll sample when it has never succeeded — gives a finite,
     # serializable "seconds since we first saw this miner" rather than
     # Infinity (which would break the webhook body's JSON.generate).
-    def populate_offline_readings(readings, now)
+    def populate_offline_readings(atom_readings, now)
       last_ok  = SampleQuery.last_ok_at_per_miner
       first_at = SampleQuery.first_poll_at_per_miner
       SnapshotQuery.miners.each do |entry|
         miner = entry[:miner]
 
         # Read-side gate: when the manager has the miner in its
-        # restart-window, suppress this miner's offline rule for this
-        # tick so the nightly restart doesn't page on its way down.
-        # Schedule lookup is fail-open (returns false on fetch failure),
-        # so a manager outage doesn't blanket-suppress real outages.
+        # restart-window, suppress this miner's offline_seconds atom
+        # for this tick so the nightly restart doesn't page on its
+        # way down. Both the built-in `offline` rule AND any composite
+        # that uses `offline_seconds` see nil and skip — composites
+        # via #evaluable?, built-ins via the `next if observed.nil?`
+        # gate in evaluate(). Schedule lookup is fail-open (returns
+        # false on fetch failure), so a manager outage doesn't
+        # blanket-suppress real outages.
         if @restart_schedule_client&.in_restart_window?(miner, now)
-          readings[miner]['offline'] = nil
+          atom_readings[miner]['offline_seconds'] = nil
           Logger.info(event: 'alert.suppressed_during_restart_window',
                       miner: miner, rule: 'offline')
           next
         end
 
         reference = last_ok[miner] || first_at[miner]
-        readings[miner]['offline'] = reference ? (now - reference).to_f : 0.0
+        atom_readings[miner]['offline_seconds'] = reference ? (now - reference).to_f : 0.0
       end
     end
 

--- a/lib/cgminer_monitor/alert_evaluator.rb
+++ b/lib/cgminer_monitor/alert_evaluator.rb
@@ -106,14 +106,15 @@ module CgminerMonitor
     def evaluate_composite_rule(composite:, miner:, readings:, now:, counts:)
       violating = composite.violates?(readings)
       state_doc = AlertState.where(_id: AlertState.composite_id(miner, composite.name)).first
+      details   = composite.payload_details(readings)
       common = {
         miner: miner, rule: composite.name,
         observed: composite.payload_observed(readings),
         threshold: composite.payload_threshold,
         unit: nil, now: now, state_doc: state_doc,
         # Composites carry per-clause structure on the wire AND in state.
-        details: composite.payload_details(readings),
-        last_observed_components: composite.payload_details(readings)['clauses']
+        details: details,
+        last_observed_components: details['clauses']
       }
 
       if violating
@@ -255,6 +256,17 @@ module CgminerMonitor
       { 'ghs_5s' => nil, 'temp_max' => nil, 'offline_seconds' => nil }
     end
 
+    # Names every currently-enabled rule that consumes the
+    # `offline_seconds` atom. Drives the per-rule emit on
+    # `alert.suppressed_during_restart_window` so the operator sees
+    # one row per affected rule, not a hardcoded `rule: 'offline'`.
+    def rules_consuming_offline_atom
+      built_ins = threshold_for('offline').nil? ? [] : ['offline']
+      composites = @config.composite_rules.select { |c| c.required_metrics.include?('offline_seconds') }
+                                          .map(&:name)
+      built_ins + composites
+    end
+
     # True when at least one rule (built-in or composite) consumes
     # the atom — drives whether `miner_states` bothers reading the
     # underlying snapshot/sample at all.
@@ -291,8 +303,14 @@ module CgminerMonitor
         # blanket-suppress real outages.
         if @restart_schedule_client&.in_restart_window?(miner, now)
           atom_readings[miner]['offline_seconds'] = nil
-          Logger.info(event: 'alert.suppressed_during_restart_window',
-                      miner: miner, rule: 'offline')
+          # Emit one suppression log per rule that consumes the atom
+          # so a composite-only deployment doesn't see a misleading
+          # `rule: 'offline'` row referencing a built-in they didn't
+          # configure.
+          rules_consuming_offline_atom.each do |rule|
+            Logger.info(event: 'alert.suppressed_during_restart_window',
+                        miner: miner, rule: rule)
+          end
           next
         end
 

--- a/lib/cgminer_monitor/alert_state.rb
+++ b/lib/cgminer_monitor/alert_state.rb
@@ -20,6 +20,12 @@ module CgminerMonitor
     field :state, type: String
     field :threshold, type: Float
     field :last_observed, type: Float
+    # Composite-rule observed snapshot. Built-in rules pass nil here
+    # (their scalar reading lives in `last_observed`). Composites pass
+    # a string-keyed Hash like { "ghs_5s" => 450.5, "temp_max" => 82.3 }.
+    # Mongoid round-trips Hash via BSON document — keep keys as Strings
+    # to avoid Symbol↔String coercion surprises across saves.
+    field :last_observed_components, type: Hash
     field :last_fired_at, type: Time
     field :last_transition_at, type: Time
 

--- a/lib/cgminer_monitor/composite_rule.rb
+++ b/lib/cgminer_monitor/composite_rule.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module CgminerMonitor
+  # Value object: an operator-defined alert rule that combines
+  # multiple atomic-metric clauses under AND semantics. Constructed
+  # by CompositeRuleParser at boot; never instantiated directly by
+  # the evaluator. The evaluator iterates `@config.composite_rules`
+  # and calls #evaluable? / #violates? / #payload_* per (rule, miner)
+  # pair using the same lifecycle (handle_violating / handle_resolved /
+  # ensure_ok_state) as the built-in rules.
+  #
+  # Frozen after construction so the boot-time parsed form can't
+  # drift while the poll loop is running.
+  class CompositeRule
+    attr_reader :name, :clauses, :required_metrics
+
+    def initialize(name:, clauses:)
+      @name             = name
+      @clauses          = clauses.freeze
+      @required_metrics = clauses.map { |c| c[:metric] }.uniq.freeze
+      @sorted_clauses   = clauses.sort_by { |c| c[:metric] }.freeze
+      freeze
+    end
+
+    # True when every metric this rule references has a non-nil
+    # reading on this tick. False → caller must skip this rule for
+    # this miner this tick (NO state write, NO emit). Mirrors the
+    # `next if observed.nil?` semantics the built-in rules use, but
+    # at the rule level instead of the per-rule loop.
+    def evaluable?(readings)
+      required_metrics.all? { |m| !readings[m].nil? }
+    end
+
+    # AND across clauses. Caller must check #evaluable? first; we
+    # raise rather than silently treating "missing" as "not
+    # violating" (which would let a transient bad snapshot transition
+    # a real violating composite to ok).
+    def violates?(readings)
+      missing = required_metrics.reject { |m| readings.key?(m) && !readings[m].nil? }
+      raise ArgumentError, "missing reading(s) for: #{missing.join(', ')}" if missing.any?
+
+      @clauses.all? { |c| clause_violates?(readings[c[:metric]], c[:op], c[:threshold]) }
+    end
+
+    # Canonical, deterministic form. Sorted by metric name so a parse
+    # → render → parse round-trip is stable. Used in the webhook's
+    # top-level `threshold:` field for composites (Slack/Discord
+    # render this string verbatim).
+    def payload_threshold
+      sorted_clauses
+        .map { |c| "#{c[:metric]}#{c[:op]}#{c[:threshold]}" }
+        .join(' & ')
+    end
+
+    # Space-separated metric=value pairs, sorted by metric. Used in
+    # the webhook's top-level `observed:` field for composites.
+    def payload_observed(readings)
+      sorted_clauses
+        .map { |c| "#{c[:metric]}=#{readings[c[:metric]]}" }
+        .join(' ')
+    end
+
+    # Structured form for the new `details:` webhook field (generic
+    # format only; Slack/Discord render the strings above). Includes
+    # the canonical expression so consumers don't have to re-derive
+    # the rule definition. ALL string keys + Float/String values for
+    # Mongoid + JSON cleanliness.
+    def payload_details(readings)
+      {
+        'expression' => payload_threshold,
+        'clauses' => sorted_clauses.to_h do |c|
+          [c[:metric], {
+            'observed' => readings[c[:metric]],
+            'threshold' => c[:threshold],
+            'op' => c[:op]
+          }]
+        end
+      }
+    end
+
+    private
+
+    attr_reader :sorted_clauses
+
+    def clause_violates?(observed, operator, threshold)
+      case operator
+      when '<'  then observed < threshold
+      when '>'  then observed > threshold
+      when '<=' then observed <= threshold
+      when '>=' then observed >= threshold
+      when '==' then observed == threshold
+      end
+    end
+  end
+end

--- a/lib/cgminer_monitor/composite_rule_parser.rb
+++ b/lib/cgminer_monitor/composite_rule_parser.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module CgminerMonitor
+  # Parses operator-defined composite alert rule expressions into
+  # CompositeRule value objects. Grammar (deliberately tiny — see
+  # docs/log_schema.md and README's "Composite alert rules" section
+  # for the long form):
+  #
+  #   <expr>   := <clause> ( "&" <clause> )+    # at least 2 clauses
+  #   <clause> := <metric> <op> <number>
+  #   <metric> := one of ALLOWED_METRICS
+  #   <op>     := one of ALLOWED_OPS  (longest-first matching: <= before <)
+  #   <number> := decimal (sign + integer + optional fractional)
+  #
+  # Anything else — parens, OR (`|`), unknown metrics, unknown ops,
+  # non-numeric thresholds, single-clause expressions — fails fast
+  # at boot with a ConfigError that aggregates EVERY clause-level
+  # problem in one message so the operator doesn't have to fix-and-
+  # rerun N times.
+  class CompositeRuleParser
+    ALLOWED_METRICS = %w[ghs_5s temp_max offline_seconds].freeze
+    # Order matters: longest-first so `<=` and `>=` aren't mis-tokenized
+    # as `<` / `>`. The CLAUSE_REGEX below relies on alternation order.
+    ALLOWED_OPS = %w[<= >= == < >].freeze
+    RESERVED_NAMES = %w[hashrate_below temperature_above offline].freeze
+
+    # Anchored, full-match regex per clause. The op alternation lists
+    # multi-char ops first (Ruby Regexp alternation is left-to-right
+    # and greedy on the matched alternative).
+    CLAUSE_REGEX = /\A\s*(\w+)\s*(<=|>=|==|<|>)\s*(-?\d+(?:\.\d+)?)\s*\z/
+
+    def self.parse(name, expr)
+      new(name, expr).parse
+    end
+
+    def initialize(name, expr)
+      @name = name.to_s
+      @expr = expr.to_s
+    end
+
+    def parse
+      raise_collision if RESERVED_NAMES.include?(@name)
+
+      stripped = @expr.strip
+      raise CgminerMonitor::ConfigError, "composite rule `#{@name}`: expression empty" if stripped.empty?
+
+      # OR / `|` is explicitly out of scope for v1.4.0 — surface a
+      # specific message rather than letting it fall through as
+      # "unknown operator" or "unknown metric foo|bar".
+      if stripped.include?('|')
+        raise CgminerMonitor::ConfigError,
+              "composite rule `#{@name}`: only AND (`&`) supported, found `|`"
+      end
+
+      raw_clauses = stripped.split('&')
+      if raw_clauses.size < 2
+        raise CgminerMonitor::ConfigError,
+              "composite rule `#{@name}`: must have at least 2 clauses (single-clause " \
+              'composites duplicate built-in rules — use the built-in instead)'
+      end
+
+      errors  = []
+      clauses = raw_clauses.map { |raw| parse_clause(raw, errors) }
+
+      raise CgminerMonitor::ConfigError, "composite rule `#{@name}`: #{errors.join('; ')}" if errors.any?
+
+      CompositeRule.new(name: @name, clauses: clauses)
+    end
+
+    private
+
+    def parse_clause(raw, errors)
+      match = CLAUSE_REGEX.match(raw)
+      unless match
+        errors << "malformed clause `#{raw.strip}` (expected `metric op number`)"
+        return nil
+      end
+
+      metric = match[1]
+      op = match[2]
+      threshold_str = match[3]
+
+      unless ALLOWED_METRICS.include?(metric)
+        errors << "unknown metric `#{metric}` (allowed: #{ALLOWED_METRICS.join(', ')})"
+      end
+
+      errors << "unknown operator `#{op}` in clause `#{raw.strip}`" unless ALLOWED_OPS.include?(op)
+
+      threshold = Float(threshold_str, exception: false)
+      errors << "non-numeric threshold `#{threshold_str}` in clause `#{raw.strip}`" if threshold.nil?
+
+      { metric: metric, op: op, threshold: threshold }
+    end
+
+    def raise_collision
+      raise CgminerMonitor::ConfigError,
+            "composite rule `#{@name}`: name collides with a built-in rule " \
+            "(reserved: #{RESERVED_NAMES.join(', ')})"
+    end
+  end
+end

--- a/lib/cgminer_monitor/config.rb
+++ b/lib/cgminer_monitor/config.rb
@@ -23,6 +23,7 @@ module CgminerMonitor
     :alerts_offline_after_seconds,
     :alerts_cooldown_seconds,
     :alerts_webhook_timeout_seconds,
+    :composite_rules,
     :restart_schedule_url,
     :restart_window_grace_seconds
   ) do
@@ -67,12 +68,15 @@ module CgminerMonitor
       raise ConfigError, "alerts_cooldown_seconds must be > 0" unless alerts_cooldown_seconds.positive?
       raise ConfigError, "alerts_webhook_timeout_seconds must be > 0" unless alerts_webhook_timeout_seconds.positive?
 
-      return if alerts_hashrate_min_ghs || alerts_temperature_max_c || alerts_offline_after_seconds
+      return if alerts_hashrate_min_ghs || alerts_temperature_max_c ||
+                alerts_offline_after_seconds || composite_rules.any?
 
       raise ConfigError,
-            "alerts_enabled=true but no rule threshold configured " \
-            "(set at least one of ALERTS_HASHRATE_MIN_GHS / " \
-            "ALERTS_TEMPERATURE_MAX_C / ALERTS_OFFLINE_AFTER_SECONDS)"
+            "alerts_enabled=true but no rule configured " \
+            "(set at least one of CGMINER_MONITOR_ALERTS_HASHRATE_MIN_GHS / " \
+            "CGMINER_MONITOR_ALERTS_TEMPERATURE_MAX_C / " \
+            "CGMINER_MONITOR_ALERTS_OFFLINE_AFTER_SECONDS, " \
+            "or define a composite via CGMINER_MONITOR_ALERTS_COMPOSITE_*)"
     end
 
     def redact_mongo_url(url)
@@ -120,6 +124,7 @@ module CgminerMonitor
         alerts_offline_after_seconds: parse_optional_int(env, "CGMINER_MONITOR_ALERTS_OFFLINE_AFTER_SECONDS"),
         alerts_cooldown_seconds: parse_int(env, "CGMINER_MONITOR_ALERTS_COOLDOWN_SECONDS", "300"),
         alerts_webhook_timeout_seconds: parse_int(env, "CGMINER_MONITOR_ALERTS_WEBHOOK_TIMEOUT_SECONDS", "2"),
+        composite_rules: parse_composite_rules(env),
         restart_schedule_url: env["CGMINER_MONITOR_RESTART_SCHEDULE_URL"],
         restart_window_grace_seconds: parse_int(env, "CGMINER_MONITOR_RESTART_WINDOW_GRACE_SECONDS", "300")
       ).validate!
@@ -175,6 +180,28 @@ module CgminerMonitor
       Integer(env[key])
     rescue ArgumentError, TypeError
       raise ConfigError, "#{key} must be a valid integer, got: #{env[key].inspect}"
+    end
+
+    COMPOSITE_PREFIX = "CGMINER_MONITOR_ALERTS_COMPOSITE_"
+    private_constant :COMPOSITE_PREFIX
+
+    # Discovers composite rule ENV vars by prefix scan, then routes
+    # each through CompositeRuleParser. Suffix becomes the lowercased
+    # rule name (e.g. *_THERMAL_STRESS → "thermal_stress"). Parser
+    # errors are re-raised with the originating ENV var name prefixed
+    # so the operator sees which composite is broken without grepping.
+    def parse_composite_rules(env)
+      env.keys.grep(/\A#{Regexp.escape(COMPOSITE_PREFIX)}(.+)\z/).sort.map do |key|
+        suffix = key.sub(/\A#{Regexp.escape(COMPOSITE_PREFIX)}/, '')
+        name   = suffix.downcase
+        expr   = env[key].to_s
+
+        begin
+          CompositeRuleParser.parse(name, expr)
+        rescue ConfigError => e
+          raise ConfigError, "#{key}: #{e.message.sub(/\Acomposite rule `[^`]+`: /, '')}"
+        end
+      end
     end
   end
 end

--- a/lib/cgminer_monitor/version.rb
+++ b/lib/cgminer_monitor/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CgminerMonitor
-  VERSION = "1.3.3"
+  VERSION = "1.4.0"
 
   def self.version
     VERSION

--- a/lib/cgminer_monitor/webhook_client.rb
+++ b/lib/cgminer_monitor/webhook_client.rb
@@ -26,9 +26,10 @@ module CgminerMonitor
       @timeout = config.alerts_webhook_timeout_seconds
     end
 
-    def fire(event:, miner:, rule:, threshold:, observed:, unit:, fired_at:)
+    def fire(event:, miner:, rule:, threshold:, observed:, unit:, fired_at:, details: nil)
       payload = { event: event, miner: miner, rule: rule, threshold: threshold,
-                  observed: observed, unit: unit, fired_at: fired_at.utc.iso8601(3) }
+                  observed: observed, unit: unit, fired_at: fired_at.utc.iso8601(3),
+                  details: details }
       post(JSON.generate(body_for(payload)), miner: miner, rule: rule)
     rescue StandardError => e
       # Belt-and-braces: any path that slipped past the inner rescue
@@ -69,7 +70,9 @@ module CgminerMonitor
     end
 
     def generic_body(payload)
-      payload.merge(severity: 'warning',
+      # Strip details: nil so the generic body shape stays clean for built-in rules.
+      generic = payload.reject { |k, v| k == :details && v.nil? }
+      generic.merge(severity: 'warning',
                     monitor: { version: CgminerMonitor::VERSION, pid: Process.pid })
     end
 
@@ -80,8 +83,8 @@ module CgminerMonitor
           color: SLACK_COLOR[payload[:event]] || 'warning',
           title: title,
           fields: [
-            { title: 'Observed',  value: "#{payload[:observed]} #{payload[:unit]}",  short: true },
-            { title: 'Threshold', value: "#{payload[:threshold]} #{payload[:unit]}", short: true }
+            { title: 'Observed',  value: render_with_unit(payload[:observed], payload[:unit]),  short: true },
+            { title: 'Threshold', value: render_with_unit(payload[:threshold], payload[:unit]), short: true }
           ],
           ts: Time.parse(payload[:fired_at]).to_i
         }]
@@ -92,12 +95,19 @@ module CgminerMonitor
       {
         embeds: [{
           title: slack_title(payload[:rule], payload[:event]),
-          description: "Miner `#{payload[:miner]}` observed #{payload[:observed]} #{payload[:unit]} " \
-                       "(threshold #{payload[:threshold]} #{payload[:unit]}).",
+          description: "Miner `#{payload[:miner]}` observed #{render_with_unit(payload[:observed], payload[:unit])} " \
+                       "(threshold #{render_with_unit(payload[:threshold], payload[:unit])}).",
           color: DISCORD_COLOR[payload[:event]] || 15_844_367,
           timestamp: payload[:fired_at]
         }]
       }
+    end
+
+    # Composites pass `unit: nil` and a fully-formatted multi-metric
+    # `observed`/`threshold` string. Eliding the separator keeps Slack
+    # / Discord renderings clean (no trailing space, no double space).
+    def render_with_unit(value, unit)
+      [value, unit].compact.join(' ')
     end
 
     RULE_TITLES = {
@@ -108,7 +118,7 @@ module CgminerMonitor
     private_constant :RULE_TITLES
 
     def slack_title(rule, event)
-      base = RULE_TITLES[rule]
+      base = RULE_TITLES[rule] || "Composite alert: #{rule}"
       event == 'alert.resolved' ? "#{base} — resolved" : base
     end
   end

--- a/spec/cgminer_monitor/alert_evaluator_spec.rb
+++ b/spec/cgminer_monitor/alert_evaluator_spec.rb
@@ -529,6 +529,185 @@ RSpec.describe CgminerMonitor::AlertEvaluator do
     end
   end
 
+  describe 'composite rules' do
+    let(:composite_id_str) { "#{miner_id}|thermal_stress" }
+
+    def composite_config(extra = {})
+      make_config({
+        'CGMINER_MONITOR_ALERTS_COMPOSITE_THERMAL_STRESS' => 'ghs_5s<500 & temp_max>80'
+      }.merge(extra))
+    end
+
+    def seed_violating
+      upsert_snapshot(miner: miner_id, command: 'summary',
+                      response: { 'SUMMARY' => [{ 'GHS 5s' => 450.0 }] })
+      upsert_snapshot(miner: miner_id, command: 'devs',
+                      response: { 'DEVS' => [{ 'Temperature' => 82.0 }] })
+    end
+
+    describe 'fired/resolved lifecycle' do
+      let(:config) { composite_config }
+
+      it 'fires alert.fired with composite-shaped threshold/observed/details on first violation' do
+        seed_violating
+        evaluator.evaluate(now)
+
+        state = CgminerMonitor::AlertState.find(composite_id_str)
+        expect(state.state).to eq 'violating'
+        expect(state.last_observed).to be_nil # composites use last_observed_components, not Float
+        expect(state.last_observed_components).to include('ghs_5s', 'temp_max')
+
+        expect(webhook_client).to have_received(:fire).with(
+          hash_including(
+            event: 'alert.fired',
+            rule: 'thermal_stress',
+            threshold: 'ghs_5s<500.0 & temp_max>80.0',
+            observed: 'ghs_5s=450.0 temp_max=82.0',
+            unit: nil,
+            details: hash_including('expression' => 'ghs_5s<500.0 & temp_max>80.0')
+          )
+        )
+      end
+
+      it 'does not re-fire on the next tick (state already violating, cooldown not elapsed)' do
+        seed_violating
+        evaluator.evaluate(now)
+        evaluator.evaluate(now + 30)
+        expect(webhook_client).to have_received(:fire).once
+      end
+
+      it 'fires alert.resolved when one clause clears (AND semantics → resolution on first clearing)' do
+        seed_violating
+        evaluator.evaluate(now)
+
+        # Temperature drops to safe — composite resolves even though hashrate still violates.
+        upsert_snapshot(miner: miner_id, command: 'devs',
+                        response: { 'DEVS' => [{ 'Temperature' => 70.0 }] })
+        evaluator.evaluate(now + 30)
+
+        state = CgminerMonitor::AlertState.find(composite_id_str)
+        expect(state.state).to eq 'ok'
+        expect(webhook_client).to have_received(:fire).with(
+          hash_including(event: 'alert.resolved', rule: 'thermal_stress')
+        )
+      end
+
+      it 're-fires after cooldown elapses while still violating' do
+        seed_violating
+        evaluator.evaluate(now)
+        evaluator.evaluate(now + 301) # cooldown defaults to 300s
+        expect(webhook_client).to have_received(:fire).twice.with(
+          hash_including(event: 'alert.fired', rule: 'thermal_stress')
+        )
+      end
+    end
+
+    describe 'reading bookkeeping — composite forces atom reads even when built-in is disabled' do
+      let(:config) do
+        # No CGMINER_MONITOR_ALERTS_TEMPERATURE_MAX_C set — built-in temp rule disabled,
+        # but the composite needs temp_max so the devs snapshot must still be read.
+        composite_config
+      end
+
+      it 'reads the devs snapshot for temp_max even though temperature_above is unset' do
+        seed_violating
+        expect(CgminerMonitor::Snapshot).to receive(:where)
+          .with(command: 'devs', ok: true).and_call_original
+        expect(CgminerMonitor::Snapshot).to receive(:where)
+          .with(command: 'summary', ok: true).and_call_original
+        evaluator.evaluate(now)
+      end
+    end
+
+    describe 'missing-atom semantics — skip the tick (NO state write, NO emit)' do
+      let(:config) { composite_config }
+
+      it 'does not transition a violating composite to ok when a required snapshot disappears' do
+        seed_violating
+        evaluator.evaluate(now)
+        expect(CgminerMonitor::AlertState.find(composite_id_str).state).to eq 'violating'
+
+        # Wipe the devs snapshot — temp_max becomes unreadable.
+        CgminerMonitor::Snapshot.where(miner: miner_id, command: 'devs').delete
+
+        evaluator.evaluate(now + 30)
+        # State unchanged; no resolved emitted.
+        expect(CgminerMonitor::AlertState.find(composite_id_str).state).to eq 'violating'
+        expect(webhook_client).to have_received(:fire).once # the original fire, no resolve
+      end
+
+      it 'does not create an ok state doc when a required reading is missing on first sight' do
+        upsert_snapshot(miner: miner_id, command: 'summary',
+                        response: { 'SUMMARY' => [{ 'GHS 5s' => 450.0 }] })
+        # No devs snapshot at all — temp_max is nil.
+        evaluator.evaluate(now)
+        expect(CgminerMonitor::AlertState.where(_id: composite_id_str).first).to be_nil
+      end
+    end
+
+    describe 'cooldown asymmetry — fires debounced, resolves emit unconditionally on transition' do
+      let(:config) { composite_config }
+
+      it 'can fire→resolve→fire within one cooldown window when conditions flap' do
+        # Tick 1: violating → fire
+        seed_violating
+        evaluator.evaluate(now)
+        # Tick 2: temp drops, composite resolves (resolves are NOT debounced)
+        upsert_snapshot(miner: miner_id, command: 'devs',
+                        response: { 'DEVS' => [{ 'Temperature' => 70.0 }] })
+        evaluator.evaluate(now + 30)
+        # Tick 3: temp re-rises well before cooldown elapsed (60s < 300s default),
+        # composite re-fires — cooldown only debounces violating→violating, and the
+        # state is now ok again so the next violation transition fires immediately.
+        upsert_snapshot(miner: miner_id, command: 'devs',
+                        response: { 'DEVS' => [{ 'Temperature' => 82.0 }] })
+        evaluator.evaluate(now + 60)
+
+        expect(webhook_client).to have_received(:fire).exactly(3).times
+        expect(webhook_client).to have_received(:fire).twice.with(hash_including(event: 'alert.fired'))
+        expect(webhook_client).to have_received(:fire).once.with(hash_including(event: 'alert.resolved'))
+      end
+    end
+
+    describe 'built-in + composite double-fire on the same observation (intentional)' do
+      let(:config) do
+        composite_config('CGMINER_MONITOR_ALERTS_TEMPERATURE_MAX_C' => '80')
+      end
+
+      it 'emits alert.fired for BOTH temperature_above and thermal_stress when both apply' do
+        seed_violating
+        # ghs_5s=450 doesn't trip a hashrate rule (not configured), but temp=82 trips
+        # the built-in temperature_above (>80) AND the thermal_stress composite.
+        evaluator.evaluate(now)
+
+        expect(webhook_client).to have_received(:fire).with(
+          hash_including(event: 'alert.fired', rule: 'temperature_above')
+        )
+        expect(webhook_client).to have_received(:fire).with(
+          hash_including(event: 'alert.fired', rule: 'thermal_stress')
+        )
+      end
+    end
+
+    describe 'startup config_loaded log line' do
+      let(:log_io) { StringIO.new }
+
+      it 'emits one alert.config_loaded line listing built-in rules and composite rule names' do
+        CgminerMonitor::Logger.output = log_io
+        CgminerMonitor::Logger.level = 'info'
+
+        described_class.new(composite_config('CGMINER_MONITOR_ALERTS_TEMPERATURE_MAX_C' => '80'),
+                            webhook_client: webhook_client)
+
+        loaded = log_io.string.lines.map { |l| JSON.parse(l) }
+                                    .find { |l| l['event'] == 'alert.config_loaded' }
+        expect(loaded).not_to be_nil
+        expect(loaded['built_in_rules']).to eq(['temperature_above'])
+        expect(loaded['composite_rules']).to eq(['thermal_stress'])
+      end
+    end
+  end
+
   describe 'alert.evaluation_complete' do
     let(:config) { make_config('CGMINER_MONITOR_ALERTS_HASHRATE_MIN_GHS' => '1000') }
     let(:log_io) { StringIO.new }

--- a/spec/cgminer_monitor/alert_evaluator_spec.rb
+++ b/spec/cgminer_monitor/alert_evaluator_spec.rb
@@ -416,6 +416,48 @@ RSpec.describe CgminerMonitor::AlertEvaluator do
           hash_including(rule: 'hashrate_below')
         )
       end
+
+      it 'emits one suppression log per rule that consumes offline_seconds (built-in + composites)' do
+        log_io = StringIO.new
+        CgminerMonitor::Logger.output = log_io
+        CgminerMonitor::Logger.level = 'info'
+
+        composite_config = make_config(
+          'CGMINER_MONITOR_ALERTS_OFFLINE_AFTER_SECONDS' => '600',
+          'CGMINER_MONITOR_ALERTS_COMPOSITE_COLD_DEAD' => 'ghs_5s<100 & offline_seconds>60'
+        )
+        evaluator = described_class.new(composite_config,
+                                        webhook_client: webhook_client,
+                                        restart_schedule_client: restart_schedule_client)
+        evaluator.evaluate(now)
+
+        suppression_lines = log_io.string.lines.map { |l| JSON.parse(l) }
+                                               .select { |l| l['event'] == 'alert.suppressed_during_restart_window' }
+        rules = suppression_lines.map { |l| l['rule'] }
+        expect(rules).to contain_exactly('offline', 'cold_dead')
+      end
+
+      it 'omits the built-in `offline` suppression row when only composites consume offline_seconds' do
+        log_io = StringIO.new
+        CgminerMonitor::Logger.output = log_io
+        CgminerMonitor::Logger.level = 'info'
+
+        # No CGMINER_MONITOR_ALERTS_OFFLINE_AFTER_SECONDS — built-in offline rule disabled.
+        composite_only_config = CgminerMonitor::Config.from_env(
+          base_env.merge(
+            'CGMINER_MONITOR_ALERTS_COMPOSITE_COLD_DEAD' => 'ghs_5s<100 & offline_seconds>60'
+          )
+        )
+        evaluator = described_class.new(composite_only_config,
+                                        webhook_client: webhook_client,
+                                        restart_schedule_client: restart_schedule_client)
+        evaluator.evaluate(now)
+
+        suppression_lines = log_io.string.lines.map { |l| JSON.parse(l) }
+                                               .select { |l| l['event'] == 'alert.suppressed_during_restart_window' }
+        rules = suppression_lines.map { |l| l['rule'] }
+        expect(rules).to eq(['cold_dead']) # NOT 'offline' — that built-in is disabled
+      end
     end
 
     context 'with a restart_schedule_client reporting the miner is NOT in its window' do

--- a/spec/cgminer_monitor/alert_state_spec.rb
+++ b/spec/cgminer_monitor/alert_state_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CgminerMonitor::AlertState do
+  let(:miner) { '10.0.0.5:4028' }
+  let(:rule)  { 'thermal_stress' }
+
+  describe '#last_observed_components round-trip' do
+    it 'persists a string-keyed Float-valued hash and re-reads it intact (fresh fetch)' do
+      doc = described_class.new(miner: miner, rule: rule, state: 'violating',
+                                threshold: nil, last_observed: nil,
+                                last_observed_components: { 'ghs_5s' => 450.5, 'temp_max' => 82.3 },
+                                last_fired_at: Time.now.utc, last_transition_at: Time.now.utc)
+      doc.save!
+
+      # Force a fresh fetch — Mongoid's in-memory hash isn't proof of round-trip.
+      reloaded = described_class.find(described_class.composite_id(miner, rule))
+      expect(reloaded.last_observed_components).to eq('ghs_5s' => 450.5, 'temp_max' => 82.3)
+    end
+
+    it 'leaves last_observed_components nil for built-in-rule docs (backward-compat default)' do
+      doc = described_class.new(miner: miner, rule: 'temperature_above', state: 'violating',
+                                threshold: 80.0, last_observed: 82.0,
+                                last_fired_at: Time.now.utc, last_transition_at: Time.now.utc)
+      doc.save!
+
+      reloaded = described_class.find(described_class.composite_id(miner, 'temperature_above'))
+      expect(reloaded.last_observed_components).to be_nil
+    end
+
+    it 'tolerates Symbol-keyed hashes by coercing keys to strings on read (Mongoid + BSON behavior)' do
+      # Defensive: if a future caller forgets to pre-stringify, what comes back from Mongo?
+      # We pin the actual behavior so a regression surfaces here, not at webhook fire time.
+      doc = described_class.new(miner: miner, rule: rule, state: 'violating',
+                                last_observed_components: { ghs_5s: 450.5, temp_max: 82.3 },
+                                last_fired_at: Time.now.utc, last_transition_at: Time.now.utc)
+      doc.save!
+
+      reloaded = described_class.find(described_class.composite_id(miner, rule))
+      # BSON serializes Symbol keys to Strings on the wire — verify what we actually get back.
+      keys = reloaded.last_observed_components.keys
+      expect(keys.all?(String)).to be(true), "expected all string keys, got: #{keys.map(&:class)}"
+    end
+  end
+end

--- a/spec/cgminer_monitor/composite_rule_spec.rb
+++ b/spec/cgminer_monitor/composite_rule_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CgminerMonitor::CompositeRule do
+  let(:rule) { CgminerMonitor::CompositeRuleParser.parse('thermal_stress', 'ghs_5s<500 & temp_max>80') }
+
+  describe 'parser — happy path' do
+    it 'parses a two-clause AND expression' do
+      expect(rule.name).to eq('thermal_stress')
+      expect(rule.clauses.size).to eq(2)
+      metrics = rule.clauses.map { |c| c[:metric] }
+      expect(metrics).to contain_exactly('ghs_5s', 'temp_max')
+    end
+
+    it 'normalizes whitespace around the AND token and around operators' do
+      r = CgminerMonitor::CompositeRuleParser.parse('x', '  ghs_5s   <  500   &   temp_max  >  80  ')
+      expect(r.clauses.size).to eq(2)
+    end
+
+    it 'recognizes <=, >=, ==, <, > (longest-first matching)' do
+      r = CgminerMonitor::CompositeRuleParser.parse('x', 'ghs_5s<=500 & temp_max>=80')
+      ops = r.clauses.map { |c| c[:op] }
+      expect(ops).to contain_exactly('<=', '>=')
+    end
+  end
+
+  describe 'parser — rejection paths (one ConfigError per malformed input, listing all problems)' do
+    it 'rejects single-clause expressions (a single clause duplicates a built-in rule)' do
+      expect { CgminerMonitor::CompositeRuleParser.parse('x', 'ghs_5s<500') }
+        .to raise_error(CgminerMonitor::ConfigError, /at least 2 clauses/i)
+    end
+
+    it 'rejects unknown metric names' do
+      expect { CgminerMonitor::CompositeRuleParser.parse('x', 'foo<500 & temp_max>80') }
+        .to raise_error(CgminerMonitor::ConfigError, /unknown metric.*foo/i)
+    end
+
+    it 'rejects unknown operators' do
+      expect { CgminerMonitor::CompositeRuleParser.parse('x', 'ghs_5s!=500 & temp_max>80') }
+        .to raise_error(CgminerMonitor::ConfigError, /operator|clause/i)
+    end
+
+    it 'rejects non-numeric thresholds' do
+      expect { CgminerMonitor::CompositeRuleParser.parse('x', 'ghs_5s<abc & temp_max>80') }
+        .to raise_error(CgminerMonitor::ConfigError, /threshold|abc/i)
+    end
+
+    it 'rejects OR (`|`) tokens explicitly' do
+      expect { CgminerMonitor::CompositeRuleParser.parse('x', 'ghs_5s<500 | temp_max>80') }
+        .to raise_error(CgminerMonitor::ConfigError, /only AND.*&.*supported/i)
+    end
+
+    it 'rejects empty expression' do
+      expect { CgminerMonitor::CompositeRuleParser.parse('x', '') }
+        .to raise_error(CgminerMonitor::ConfigError, /empty/i)
+    end
+
+    it 'rejects whitespace-only expression' do
+      expect { CgminerMonitor::CompositeRuleParser.parse('x', '   ') }
+        .to raise_error(CgminerMonitor::ConfigError, /empty/i)
+    end
+
+    it 'aggregates multiple errors into a single ConfigError message' do
+      err = nil
+      begin
+        CgminerMonitor::CompositeRuleParser.parse('x', 'foo<bar & baz!=qux')
+      rescue CgminerMonitor::ConfigError => e
+        err = e
+      end
+      expect(err).not_to be_nil
+      # Each clause has problems; the aggregated message should reference all of them.
+      expect(err.message).to match(/foo/)
+      expect(err.message).to match(/baz/)
+    end
+  end
+
+  describe '#evaluable? — composites skip ticks with any missing required reading' do
+    it 'is true when every required atom reading is present' do
+      expect(rule.evaluable?('ghs_5s' => 450, 'temp_max' => 82)).to be true
+    end
+
+    it 'is false when any required atom reading is nil' do
+      expect(rule.evaluable?('ghs_5s' => nil, 'temp_max' => 82)).to be false
+      expect(rule.evaluable?('ghs_5s' => 450, 'temp_max' => nil)).to be false
+    end
+
+    it 'ignores readings the composite does not reference' do
+      readings = { 'ghs_5s' => 450, 'temp_max' => 82, 'offline_seconds' => nil }
+      expect(rule.evaluable?(readings)).to be true
+    end
+  end
+
+  describe '#violates?' do
+    it 'is true when every clause violates' do
+      expect(rule.violates?('ghs_5s' => 450, 'temp_max' => 82)).to be true
+    end
+
+    it 'is false when any one clause does not violate' do
+      expect(rule.violates?('ghs_5s' => 600, 'temp_max' => 82)).to be false
+      expect(rule.violates?('ghs_5s' => 450, 'temp_max' => 70)).to be false
+    end
+
+    it 'raises when called with missing readings (caller must check #evaluable? first)' do
+      expect { rule.violates?('ghs_5s' => nil, 'temp_max' => 82) }
+        .to raise_error(ArgumentError, /missing reading/i)
+    end
+  end
+
+  describe 'payload formatting' do
+    it 'renders payload_threshold in a canonical, deterministic form (sorted by metric name)' do
+      out_of_order = CgminerMonitor::CompositeRuleParser.parse('x', 'temp_max>80 & ghs_5s<500')
+      expect(out_of_order.payload_threshold).to eq('ghs_5s<500.0 & temp_max>80.0')
+      expect(rule.payload_threshold).to eq('ghs_5s<500.0 & temp_max>80.0')
+    end
+
+    it 'round-trips through the parser (parse → payload_threshold → parse → equal canonical form)' do
+      first = rule.payload_threshold
+      reparsed = CgminerMonitor::CompositeRuleParser.parse('thermal_stress', first)
+      expect(reparsed.payload_threshold).to eq(first)
+    end
+
+    it 'renders payload_observed as space-separated metric=value pairs (sorted by metric)' do
+      expect(rule.payload_observed('ghs_5s' => 450.5, 'temp_max' => 82.3))
+        .to eq('ghs_5s=450.5 temp_max=82.3')
+    end
+
+    it 'renders payload_details with string-keyed hashes including the canonical expression' do
+      details = rule.payload_details('ghs_5s' => 450.5, 'temp_max' => 82.3)
+      expect(details['expression']).to eq('ghs_5s<500.0 & temp_max>80.0')
+      expect(details['clauses']['ghs_5s']).to eq('observed' => 450.5, 'threshold' => 500.0, 'op' => '<')
+      expect(details['clauses']['temp_max']).to eq('observed' => 82.3, 'threshold' => 80.0, 'op' => '>')
+    end
+  end
+
+  describe 'reserved-name guard' do
+    %w[hashrate_below temperature_above offline].each do |reserved|
+      it "rejects the reserved built-in name `#{reserved}`" do
+        expect { CgminerMonitor::CompositeRuleParser.parse(reserved, 'ghs_5s<500 & temp_max>80') }
+          .to raise_error(CgminerMonitor::ConfigError, /collides with a built-in rule/i)
+      end
+    end
+  end
+end

--- a/spec/cgminer_monitor/config_spec.rb
+++ b/spec/cgminer_monitor/config_spec.rb
@@ -279,11 +279,18 @@ RSpec.describe CgminerMonitor::Config do
           .to raise_error(CgminerMonitor::ConfigError, /alerts_webhook_timeout_seconds must be > 0/)
       end
 
-      it 'raises when enabled but no rule threshold configured' do
+      it 'raises when enabled but no rule (threshold or composite) configured' do
         env = alerts_env.dup
         env.delete('CGMINER_MONITOR_ALERTS_TEMPERATURE_MAX_C')
         expect { described_class.from_env(env) }
-          .to raise_error(CgminerMonitor::ConfigError, /no rule threshold configured/)
+          .to raise_error(CgminerMonitor::ConfigError) do |e|
+            expect(e.message).to match(/no rule configured/)
+            # Operator must see all four ways to satisfy the validation.
+            expect(e.message).to include('CGMINER_MONITOR_ALERTS_HASHRATE_MIN_GHS')
+            expect(e.message).to include('CGMINER_MONITOR_ALERTS_TEMPERATURE_MAX_C')
+            expect(e.message).to include('CGMINER_MONITOR_ALERTS_OFFLINE_AFTER_SECONDS')
+            expect(e.message).to include('CGMINER_MONITOR_ALERTS_COMPOSITE_*')
+          end
       end
 
       it 'accepts each of the three rule thresholds independently' do
@@ -300,6 +307,55 @@ RSpec.describe CgminerMonitor::Config do
         expect do
           described_class.from_env(base.merge('CGMINER_MONITOR_ALERTS_OFFLINE_AFTER_SECONDS' => '600'))
         end.not_to raise_error
+      end
+    end
+
+    describe 'composite_rules' do
+      let(:base) do
+        valid_env.merge(
+          'CGMINER_MONITOR_ALERTS_ENABLED' => 'true',
+          'CGMINER_MONITOR_ALERTS_WEBHOOK_URL' => 'http://example.com/hook'
+        )
+      end
+
+      it 'discovers composite rules by ENV var prefix and lowercases the name' do
+        env = base.merge(
+          'CGMINER_MONITOR_ALERTS_COMPOSITE_THERMAL_STRESS' => 'ghs_5s<500 & temp_max>80',
+          'CGMINER_MONITOR_ALERTS_COMPOSITE_COLD_DEAD' => 'ghs_5s<100 & temp_max<30'
+        )
+        config = described_class.from_env(env)
+        expect(config.composite_rules.map(&:name)).to contain_exactly('thermal_stress', 'cold_dead')
+      end
+
+      it 'boots cleanly with ONLY a composite (no per-threshold ENV)' do
+        env = base.merge('CGMINER_MONITOR_ALERTS_COMPOSITE_THERMAL_STRESS' => 'ghs_5s<500 & temp_max>80')
+        expect { described_class.from_env(env) }.not_to raise_error
+      end
+
+      it 'rejects a composite name that collides with a built-in rule' do
+        env = base.merge(
+          'CGMINER_MONITOR_ALERTS_TEMPERATURE_MAX_C' => '85',
+          'CGMINER_MONITOR_ALERTS_COMPOSITE_HASHRATE_BELOW' => 'ghs_5s<500 & temp_max>80'
+        )
+        expect { described_class.from_env(env) }
+          .to raise_error(CgminerMonitor::ConfigError, /collides with a built-in rule/)
+      end
+
+      it 'prefixes parser errors with the originating ENV var name' do
+        env = base.merge(
+          'CGMINER_MONITOR_ALERTS_TEMPERATURE_MAX_C' => '85',
+          'CGMINER_MONITOR_ALERTS_COMPOSITE_THERMAL_STRESS' => 'foo<500 & temp_max>80'
+        )
+        expect { described_class.from_env(env) }
+          .to raise_error(CgminerMonitor::ConfigError) do |e|
+            expect(e.message).to start_with('CGMINER_MONITOR_ALERTS_COMPOSITE_THERMAL_STRESS:')
+            expect(e.message).to match(/unknown metric.*foo/)
+          end
+      end
+
+      it 'defaults to an empty composite_rules list when no composite ENV vars are set' do
+        config = described_class.from_env(valid_env)
+        expect(config.composite_rules).to eq([])
       end
     end
 

--- a/spec/cgminer_monitor/webhook_client_spec.rb
+++ b/spec/cgminer_monitor/webhook_client_spec.rb
@@ -128,6 +128,71 @@ RSpec.describe CgminerMonitor::WebhookClient do
     end
   end
 
+  describe 'composite-rule payload (details + unit elision)' do
+    let(:composite_payload) do
+      { event: 'alert.fired',
+        miner: '10.0.0.5:4028',
+        rule: 'thermal_stress',
+        threshold: 'ghs_5s<500.0 & temp_max>80.0',
+        observed: 'ghs_5s=450.5 temp_max=82.3',
+        unit: nil,
+        fired_at: fired_at,
+        details: { 'expression' => 'ghs_5s<500.0 & temp_max>80.0',
+                   'clauses' => { 'ghs_5s' => { 'observed' => 450.5, 'threshold' => 500.0, 'op' => '<' } } } }
+    end
+
+    context 'with generic format' do
+      let(:config) { make_config('generic') }
+
+      it 'includes the structured details hash in the body' do
+        stub_request(:post, webhook_url).to_return(status: 200)
+        client.fire(**composite_payload)
+
+        body = last_posted_body
+        expect(body['rule']).to eq 'thermal_stress'
+        expect(body['unit']).to be_nil
+        expect(body['details']).to include('expression' => 'ghs_5s<500.0 & temp_max>80.0')
+      end
+
+      it 'omits the details key from built-in-rule payloads (no nil noise)' do
+        stub_request(:post, webhook_url).to_return(status: 200)
+        client.fire(**payload) # built-in rule, no details: passed
+        expect(last_posted_body).not_to have_key('details')
+      end
+    end
+
+    context 'with slack format' do
+      let(:config) { make_config('slack') }
+
+      it 'renders observed/threshold without trailing space when unit is nil' do
+        stub_request(:post, webhook_url).to_return(status: 200)
+        client.fire(**composite_payload)
+
+        att = last_posted_body.fetch('attachments').first
+        expect(att['title']).to include('Composite alert: thermal_stress')
+        observed = att['fields'].find { |f| f['title'] == 'Observed' }
+        threshold = att['fields'].find { |f| f['title'] == 'Threshold' }
+        expect(observed['value']).to eq 'ghs_5s=450.5 temp_max=82.3' # no trailing " "
+        expect(threshold['value']).to eq 'ghs_5s<500.0 & temp_max>80.0'
+      end
+    end
+
+    context 'with discord format' do
+      let(:config) { make_config('discord') }
+
+      it 'renders description without double spaces when unit is nil' do
+        stub_request(:post, webhook_url).to_return(status: 204)
+        client.fire(**composite_payload)
+
+        embed = last_posted_body.fetch('embeds').first
+        expect(embed['title']).to eq 'Composite alert: thermal_stress'
+        expect(embed['description']).to include('observed ghs_5s=450.5 temp_max=82.3 ')
+        expect(embed['description']).to include('(threshold ghs_5s<500.0 & temp_max>80.0)')
+        expect(embed['description']).not_to include('  ') # no double spaces
+      end
+    end
+  end
+
   describe 'failure handling' do
     let(:config) { make_config('generic') }
     let(:log_io) { StringIO.new }

--- a/spec/integration/alerts_integration_spec.rb
+++ b/spec/integration/alerts_integration_spec.rb
@@ -160,4 +160,39 @@ RSpec.describe 'Alerts integration', :integration do
       expect(posted['rule']).to eq 'offline'
     end
   end
+
+  context 'composite rule through the real evaluator + webhook' do
+    let(:composite_config) do
+      CgminerMonitor::Config.from_env(
+        'CGMINER_MONITOR_MINERS_FILE' => miners_file_path,
+        'CGMINER_MONITOR_ALERTS_ENABLED' => 'true',
+        'CGMINER_MONITOR_ALERTS_WEBHOOK_URL' => webhook_url,
+        'CGMINER_MONITOR_ALERTS_WEBHOOK_FORMAT' => 'generic',
+        'CGMINER_MONITOR_ALERTS_COMPOSITE_THERMAL_STRESS' => 'ghs_5s<500 & temp_max>80',
+        'CGMINER_MONITOR_ALERTS_COOLDOWN_SECONDS' => '60',
+        'CGMINER_MONITOR_ALERTS_WEBHOOK_TIMEOUT_SECONDS' => '2'
+      )
+    end
+
+    let(:composite_evaluator) { CgminerMonitor::AlertEvaluator.new(composite_config) }
+
+    it 'fires once with composite-shaped threshold/observed/details on a violating fleet' do
+      upsert_snapshot(miner: miner_id, command: 'summary',
+                      response: { 'SUMMARY' => [{ 'GHS 5s' => 450.0 }] })
+      upsert_snapshot(miner: miner_id, command: 'devs',
+                      response: { 'DEVS' => [{ 'Temperature' => 82.0 }] })
+
+      composite_evaluator.evaluate(Time.now.utc)
+
+      expect(WebMock).to have_requested(:post, webhook_url).once
+      body = JSON.parse(WebMock::RequestRegistry.instance.requested_signatures.hash.keys.last.body)
+      expect(body['event']).to eq 'alert.fired'
+      expect(body['rule']).to eq 'thermal_stress'
+      expect(body['threshold']).to eq 'ghs_5s<500.0 & temp_max>80.0'
+      expect(body['observed']).to eq 'ghs_5s=450.0 temp_max=82.0'
+      expect(body['unit']).to be_nil
+      expect(body['details']).to include('expression' => 'ghs_5s<500.0 & temp_max>80.0')
+      expect(body['details']['clauses']).to include('ghs_5s', 'temp_max')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Combine multiple atomic-metric clauses into a single named alert rule with **AND** semantics so a correlated fault (low hashrate + high temperature = thermal-stressed rig) fires one alert instead of two. Configure one composite per ENV var; the suffix becomes the rule name (lowercased).

\`\`\`bash
CGMINER_MONITOR_ALERTS_COMPOSITE_THERMAL_STRESS='ghs_5s<500 & temp_max>80'
\`\`\`

Composites reuse the existing fired/resolved/cooldown lifecycle and webhook sink. **OR is explicitly out of scope for v1.4.0** and triggers a specific boot-time error.

## Grammar

\`\`\`
<expr>   := <clause> ('&' <clause>)+    # at least 2 clauses
<clause> := <metric> <op> <number>
<metric> := one of {ghs_5s, temp_max, offline_seconds}
<op>     := one of {<, >, <=, >=, ==}   # multi-char ops matched longest-first
\`\`\`

A malformed composite fails fast at startup with a \`ConfigError\` that prefixes the originating ENV var name (e.g. \`CGMINER_MONITOR_ALERTS_COMPOSITE_THERMAL_STRESS: unknown metric 'foo'…\`).

## Wire-shape changes

\`alert.fired\` / \`alert.resolved\` for composites:

- \`threshold\`: String (canonical \`metric op number & ...\` form)
- \`observed\`: String (space-separated \`metric=value\` pairs)
- \`unit\`: \`null\` (Slack/Discord renderers elide the separator)
- New optional \`details\` Hash: \`{expression, clauses: {metric: {observed, threshold, op}}}\`
- New \`alert.config_loaded\` log line emitted once at AlertEvaluator construction listing enabled built-in + composite rule names

Built-in-rule events are unchanged. \`AlertState\` gains a nullable \`last_observed_components: Hash\` field; built-ins leave it nil.

## Design decisions worth calling out

- **Composite alongside, not polymorphic refactor of all rules.** Smaller diff, no regression risk on shipped built-ins. A polymorphic refactor can come later when OR motivates it.
- **Missing-atom semantics: skip the tick.** If any required atom reading is missing (no relevant snapshot, restart-window suppression on \`offline_seconds\`, etc.) the composite is skipped — no state write, no fire/resolve. Protects against transient bad data silently transitioning a real violating composite to ok.
- **Built-in + composite double-fire is by design.** If the built-in \`temperature_above\` AND a composite using \`temp_max\` are both configured, both fire on the same observation. Operator opted into both.
- **Cooldown asymmetry inherited as-documented.** Fires are debounced; resolves emit on every transition. Documented in the README's gotchas.

## Follow-up (out of scope)

- \`cgminer_manager\`'s dashboard may bucket composite rule names under "(unknown rule)" if it hard-codes the three built-in names. Tracked separately.

## Test plan

- [x] \`bundle exec rake\` — 280 examples / 0 failures, RuboCop clean
- [x] CompositeRule + parser unit specs (24 examples — grammar accept/reject, AND violation, missing-atom guard, payload formatting, parser round-trip)
- [x] Config spec additions (4 examples — discovery, name-collision rejection, composite-only boots, error-message format)
- [x] AlertState round-trip with \`last_observed_components\` (3 examples — fresh fetch from Mongo)
- [x] WebhookClient composite-payload + unit-elision (4 examples — generic includes details, slack/discord render without trailing/double spaces, RULE_TITLES fallback)
- [x] AlertEvaluator composite block (10 examples — fired/resolved lifecycle, cooldown, missing-atom skip, double-fire, flap, config_loaded log)
- [x] Integration spec — full end-to-end through real AlertEvaluator + WebMock sink, asserts the wire-shape including \`details\` hash
- [ ] CI green on full Mongo matrix