### PR TITLE
Reserve admin.action_* event schema for manager v1.7.0 confirmation flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`docs/log_schema.md`** reserves five new `admin.action_*` events
+  for the destructive-command confirmation flow shipping in
+  `cgminer_manager` v1.7.0: `admin.action_started`,
+  `admin.action_confirmed`, `admin.action_auto_confirmed`,
+  `admin.action_cancelled`, and `admin.action_rejected` (single
+  event with `reason:` Symbol discriminator covering `:expired`,
+  `:session_mismatch`, `:evicted`, `:not_found`). New
+  `confirmation_token` standard-key row and a `reason` standard-key
+  row covering its enum values. Doc-only schema reservation;
+  manager v1.7.0 implements.
+
 ## [1.4.0] — 2026-04-25
 
 ### Added

--- a/docs/log_schema.md
+++ b/docs/log_schema.md
@@ -54,6 +54,8 @@ Keys that appear across multiple events are named consistently. When you add a n
 | `user_agent`      | string           | `"curl/8.9.1"`                              | raw `HTTP_USER_AGENT` |
 | `user`            | string or `nil`  | `"admin"`                                   | admin-surface Basic-Auth username; `nil` when unauthenticated |
 | `session_id_hash` | string           | `"a3f1e2d4b6c8"`                            | first 12 hex chars of `SHA256(session_id)`; never the raw session id |
+| `confirmation_token` | string        | UUID v4                                     | single-use 2-minute TTL token issued by the destructive-command confirmation flow (`cgminer_manager` v1.7.0+); appears on `admin.action_*` events and threads step 1 → step 2 of a two-phase POST |
+| `reason`          | string (Symbol)  | `"expired"` / `"session_mismatch"` / `"evicted"` / `"not_found"` / `"missing_credentials"` | enum-like discriminator on rejection-style events. Values vary per event (e.g. `admin.auth_failed.reason` is a different enum than `admin.action_rejected.reason`); each emit-site documents its set. |
 | `request_id`      | string           | UUID v4                                     | threads entry/exit events for a single admin POST |
 | `command`         | string           | `"version"`, `"addpool"`                    | cgminer verb or admin command name |
 | `scope`           | string           | `"all"`, `"rig-01"`, `"pool-0"`             | admin-command target selector |
@@ -145,6 +147,11 @@ Organized alphabetically within namespace. "Required" columns list keys beyond t
 | `admin.auth_misconfigured` | warn | `AdminAuth` | `request_id`, `path`, `remote_ip`, `user_agent` | |
 | `admin.command` | info | `HttpApp` via `AdminLogging.command_log_entry` | `request_id`, `user`, `remote_ip`, `user_agent`, `session_id_hash`, `command`, `scope` | `args` and other per-command extras |
 | `admin.result` | info | `HttpApp` via `AdminLogging.result_log_entry` | `request_id`, `command`, `scope`, `ok_count`, `failed_count`, `duration_ms` | `failed_codes` (count-by-`code`-value map of failed entries, e.g. `{"access_denied": 3, "unknown": 2}`; map keys obey the `code` standard-key vocabulary; empty `{}` when `failed_count == 0`) |
+| `admin.action_started` | info | `HttpApp` via `ConfirmationHelpers#issue_confirmation_token` (`cgminer_manager` v1.7.0+) | `request_id`, `confirmation_token`, `expires_at`, `command`, `scope`, `session_id_hash`, `remote_ip`, `user_agent` | `user`, `args` (subject to redaction for `manage_pools/add` actions where `args` becomes `"[REDACTED: pool credentials]"`) |
+| `admin.action_confirmed` | info | `HttpApp` (post `POST /manager/admin/confirm/:token`) | `request_id`, `confirmation_token`, `command`, `scope`, `session_id_hash`, `remote_ip`, `user_agent`, `started_age_ms` | `user`, `args` (same redaction rule) |
+| `admin.action_auto_confirmed` | info | `HttpApp` via `ConfirmationHelpers` (when `?auto_confirm=1` skips the dance) | `request_id`, `command`, `scope`, `session_id_hash`, `remote_ip`, `user_agent` | `user` |
+| `admin.action_cancelled` | info | `HttpApp` (post `DELETE /manager/admin/confirm/:token`) | `request_id`, `confirmation_token`, `command`, `scope`, `session_id_hash` | `user` |
+| `admin.action_rejected` | warn | `HttpApp` via `ConfirmationHelpers#reject_confirmation!` and `#log_eviction` | `request_id`, `confirmation_token`, `reason`, `session_id_hash` | `command`, `scope`, `user` (nil for `reason: :not_found` since the token's command/scope aren't recoverable). `reason` is one of `:expired`, `:session_mismatch`, `:evicted`, `:not_found` — single event with discriminator instead of one event per failure mode. |
 
 ### `cgminer.*` (cgminer_manager)
 


### PR DESCRIPTION
## Summary

Reserves five new `admin.action_*` event types in the canonical `docs/log_schema.md` for the destructive-command confirmation flow shipping in `cgminer_manager` v1.7.0:

- `admin.action_started` — step 1: token issued
- `admin.action_confirmed` — step 2: token consumed, dispatch fires
- `admin.action_auto_confirmed` — `?auto_confirm=1` skipped step 1
- `admin.action_cancelled` — DELETE `/confirm/:token`
- `admin.action_rejected` — single event with a `reason:` Symbol discriminator (`:expired` / `:session_mismatch` / `:evicted` / `:not_found`)

Two new standard-key rows: `confirmation_token` (UUID v4) and `reason` (enum Symbol; covers both `admin.auth_failed` and `admin.action_rejected` with per-emit-site documented enums).

Doc-only — no code changes, no version bump.

## Test plan

- [x] `bundle exec rake` clean
- [ ] CI green (RuboCop + bundle-audit only on a doc-only diff)
