### PR TITLE
Suppress offline alerts during drain (v1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] — 2026-04-26
+
+### Added
+- **`RestartScheduleClient#in_drain?(miner, now)`** — new sibling to
+  the existing `in_restart_window?` predicate. Reads `drained: true`
+  + `drained_at` (ISO8601 UTC) from the per-miner record served by
+  `cgminer_manager`'s `/api/v1/restart_schedules.json`. Defensive on
+  every field: `drained` must be exactly `true` and `drained_at`
+  must parse via `Time.iso8601`; either failing returns false
+  (fail-open, same posture as the restart-window check). Manager
+  v1.8.0 publishes the drain fields; older managers omit them and
+  this predicate returns false for every miner — no version
+  negotiation needed.
+- **`AlertEvaluator#populate_offline_readings`** consults the new
+  predicate alongside the existing restart-window check. When
+  either is true, the miner's `offline_seconds` atom nils for this
+  tick (suppressing the built-in `offline` rule AND any composite
+  that uses `offline_seconds`) and one
+  `alert.suppressed_during_restart_window` event emits per affected
+  rule with a new `cause:` Symbol field (`:restart_window` or
+  `:drain`). First-true predicate wins so a drained rig inside its
+  restart window logs `cause: :restart_window` (the
+  operationally-louder signal); both predicates falling through
+  means the offline rule fires normally. Single grep target, single
+  alerting integration; the new field is the discriminator instead
+  of a new event name.
+
 ### Changed
 - **`docs/log_schema.md`** reserves five new `admin.action_*` events
   for the destructive-command confirmation flow shipping in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `confirmation_token` standard-key row and a `reason` standard-key
   row covering its enum values. Doc-only schema reservation;
   implemented in `cgminer_manager` v1.7.0.
+- **`docs/log_schema.md`** reserves five new `drain.*` events for
+  the per-miner Drain / Resume flow shipping in `cgminer_manager`
+  v1.8.0: `drain.applied`, `drain.resumed`, `drain.failed`,
+  `drain.indeterminate`, `drain.auto_resume_giving_up`. The three
+  state-change events (`failed` / `resumed` / `indeterminate`) carry
+  a `cause:` Symbol discriminator (`:drain` / `:resume` /
+  `:auto_resume` plus `:operator` / `:auto_resume_orphan_cleared`
+  for `drain.resumed`) so all originating callers share one event
+  name. Existing `alert.suppressed_during_restart_window` event
+  gains an optional `cause:` field (`:restart_window` default,
+  `:drain` for the new path) so monitor's offline-alert suppression
+  is grep-discriminable by source. New `drained_at` and `cause`
+  standard-key rows. Doc-only schema reservation; implementation
+  follows in monitor v1.5.0 alongside the manager v1.8.0 release.
 
 ## [1.4.0] — 2026-04-25
 

--- a/docs/log_schema.md
+++ b/docs/log_schema.md
@@ -55,6 +55,8 @@ Keys that appear across multiple events are named consistently. When you add a n
 | `user`            | string or `nil`  | `"admin"`                                   | admin-surface Basic-Auth username; `nil` when unauthenticated |
 | `session_id_hash` | string           | `"a3f1e2d4b6c8"`                            | first 12 hex chars of `SHA256(session_id)`; never the raw session id |
 | `confirmation_token` | string        | UUID v4                                     | single-use 2-minute TTL token issued by the destructive-command confirmation flow (`cgminer_manager` v1.7.0+); appears on `admin.action_*` events and threads step 1 → step 2 of a two-phase POST |
+| `drained_at`      | string           | `"2026-04-26T12:00:00.000Z"`                | ISO8601 UTC timestamp marking when a miner entered drain (`cgminer_manager` v1.8.0+ Drain mode). Appears on `drain.*` events and on the per-miner record served by `/api/v1/restart_schedules.json` |
+| `cause`           | string (Symbol)  | `"drain"` / `"resume"` / `"auto_resume"` / `"restart_window"` | enum-like discriminator on events that share an event name but originate from distinct callers. Values vary per event; each emit-site documents its set. |
 | `reason`          | string (Symbol)  | `"expired"` / `"session_mismatch"` / `"evicted"` / `"not_found"` / `"missing_credentials"` | enum-like discriminator on rejection-style events. Values vary per event (e.g. `admin.auth_failed.reason` is a different enum than `admin.action_rejected.reason`); each emit-site documents its set. |
 | `request_id`      | string           | UUID v4                                     | threads entry/exit events for a single admin POST |
 | `command`         | string           | `"version"`, `"addpool"`                    | cgminer verb or admin command name |
@@ -174,7 +176,19 @@ Opt-in per-miner threshold alerts. Wire-up: `CGMINER_MONITOR_ALERTS_ENABLED=true
 | `alert.evaluation_complete` | info | `AlertEvaluator` (one per poll tick) | `duration_ms`, `rules_evaluated`, `fired_count`, `resolved_count` | |
 | `alert.evaluator_error` | error | `Poller` (catches the evaluator) | `error`, `message`, `backtrace` | |
 | `alert.state_write_failed` | error | `AlertEvaluator` | `miner`, `rule`, `error`, `message` | |
-| `alert.suppressed_during_restart_window` | info | `AlertEvaluator` (offline rule + composites using offline_seconds) | `miner`, `rule` | |
+| `alert.suppressed_during_restart_window` | info | `AlertEvaluator` (offline rule + composites using offline_seconds) | `miner`, `rule`, `cause` | | <!-- `cause` is `"restart_window"` or `"drain"` (v1.5.0+); the first-true predicate (restart-window check, then drain check) wins — the event emits ONCE per affected rule with the discriminator naming why suppression triggered. -->
+
+### `drain.*` (cgminer_manager)
+
+Per-miner Drain / Resume audit events emitted by `cgminer_manager` v1.8.0+. Drain disables pool 0 on the rig (`disablepool 0`) so it stops hashing but stays responsive on the cgminer API; Resume calls `enablepool 0`. Drain state is persisted on the per-miner `RestartSchedule` record and consumed by `cgminer_monitor`'s `RestartScheduleClient#in_drain?` to suppress `offline` alerts (see `alert.suppressed_during_restart_window` row above with `cause: "drain"`).
+
+| Event | Level | Emitter | Required keys | Optional |
+|-------|-------|---------|---------------|----------|
+| `drain.applied` | info | `HttpApp` (post `POST /miner/:id/maintenance/drain`) | `request_id`, `miner_id`, `user`, `drained_at`, `auto_resume_seconds`, `pool_index` | |
+| `drain.resumed` | info | `HttpApp` (post `POST /miner/:id/maintenance/resume`) OR `RestartScheduler` (auto-resume timer fired) | `miner_id`, `cause`, `drained_at`, `pool_index` | `request_id`, `user` (nil when `cause == auto_resume` or `auto_resume_orphan_cleared`). `cause` is `"operator"`, `"auto_resume"`, or `"auto_resume_orphan_cleared"` (the rig was removed from miners.yml while drained — drain state force-cleared, no wire call attempted). |
+| `drain.failed` | warn | `HttpApp` or `RestartScheduler` | `miner_id`, `cause`, `error`, `code` | `request_id`, `user`, `attempt_count` (auto-resume only — for backoff tracking). `cause` is `"drain"`, `"resume"`, or `"auto_resume"`. `code` follows the standard `code` Symbol vocabulary (`access_denied`, `timeout`, etc.). |
+| `drain.indeterminate` | warn | `HttpApp` or `RestartScheduler` | `miner_id`, `cause`, `pool_index` | `request_id`, `user`. `cause` is `"drain"`, `"resume"`, or `"auto_resume"`. Wire call returned `:indeterminate` (verification timed out — operator should verify rig state). For `cause: "drain"` the manager fails closed (persists `drained: true`); for `cause: "resume"` or `cause: "auto_resume"` it clears the drain state. |
+| `drain.auto_resume_giving_up` | error | `RestartScheduler` (one-shot per drain after 5 consecutive `:failed` attempts) | `miner_id`, `attempt_count` | Continues retrying at the 60-minute backoff cap with `drain.failed` (warn) emissions thereafter; recoverable when the rig comes back. |
 | `alert.webhook_failed` | warn | `WebhookClient` | `miner`, `rule`, `error`, `message` | `status` (HTTP code on non-2xx responses) |
 
 ### `healthz.*` (cgminer_monitor)

--- a/lib/cgminer_monitor/alert_evaluator.rb
+++ b/lib/cgminer_monitor/alert_evaluator.rb
@@ -293,23 +293,27 @@ module CgminerMonitor
         miner = entry[:miner]
 
         # Read-side gate: when the manager has the miner in its
-        # restart-window, suppress this miner's offline_seconds atom
-        # for this tick so the nightly restart doesn't page on its
-        # way down. Both the built-in `offline` rule AND any composite
-        # that uses `offline_seconds` see nil and skip — composites
-        # via #evaluable?, built-ins via the `next if observed.nil?`
+        # restart-window OR drain state (v1.5.0+), suppress this
+        # miner's offline_seconds atom for this tick. Both the
+        # built-in `offline` rule AND any composite that uses
+        # `offline_seconds` see nil and skip — composites via
+        # #evaluable?, built-ins via the `next if observed.nil?`
         # gate in evaluate(). Schedule lookup is fail-open (returns
         # false on fetch failure), so a manager outage doesn't
         # blanket-suppress real outages.
-        if @restart_schedule_client&.in_restart_window?(miner, now)
+        #
+        # First-true predicate wins: restart_window is checked before
+        # drain so a drained rig that ALSO happens to be inside its
+        # nightly restart window logs `cause: :restart_window` (the
+        # operationally-louder signal). One suppression event per
+        # affected rule so composite-only deployments see their
+        # composite name, not a misleading hardcoded `rule: 'offline'`.
+        suppression_cause = suppression_cause_for(miner, now)
+        if suppression_cause
           atom_readings[miner]['offline_seconds'] = nil
-          # Emit one suppression log per rule that consumes the atom
-          # so a composite-only deployment doesn't see a misleading
-          # `rule: 'offline'` row referencing a built-in they didn't
-          # configure.
           rules_consuming_offline_atom.each do |rule|
             Logger.info(event: 'alert.suppressed_during_restart_window',
-                        miner: miner, rule: rule)
+                        miner: miner, rule: rule, cause: suppression_cause)
           end
           next
         end
@@ -317,6 +321,15 @@ module CgminerMonitor
         reference = last_ok[miner] || first_at[miner]
         atom_readings[miner]['offline_seconds'] = reference ? (now - reference).to_f : 0.0
       end
+    end
+
+    def suppression_cause_for(miner, now)
+      return nil unless @restart_schedule_client
+
+      return :restart_window if @restart_schedule_client.in_restart_window?(miner, now)
+      return :drain if @restart_schedule_client.in_drain?(miner, now)
+
+      nil
     end
 
     def default_webhook_client(config)

--- a/lib/cgminer_monitor/restart_schedule_client.rb
+++ b/lib/cgminer_monitor/restart_schedule_client.rb
@@ -44,6 +44,33 @@ module CgminerMonitor
       ((now_sod - start_sod) % 86_400) < @grace_seconds
     end
 
+    # Returns true iff the miner is currently drained per the manager's
+    # per-miner record (cgminer_manager v1.8.0+ Drain mode). Drain state
+    # is consumed verbatim from the schedule entry — auto-resume timeouts
+    # are enforced on the manager side, so monitor just reports what the
+    # manager last published. `now` is unused but accepted for API
+    # symmetry with `in_restart_window?` and to leave room for future
+    # drain-window semantics.
+    #
+    # Defensive on every field: `drained` must be exactly `true` (not
+    # truthy — a stray string would oscillate suppression on transient
+    # malformed entries); `drained_at` must be a parseable ISO8601
+    # string. Either failing returns false (fail-open, same posture as
+    # the restart-window check).
+    def in_drain?(miner, _now)
+      schedule = fetch[miner]
+      return false if schedule.nil?
+      return false unless schedule['drained'] == true
+
+      drained_at = schedule['drained_at']
+      return false unless drained_at.is_a?(String)
+
+      Time.iso8601(drained_at)
+      true
+    rescue ArgumentError
+      false
+    end
+
     private
 
     def fetch

--- a/lib/cgminer_monitor/version.rb
+++ b/lib/cgminer_monitor/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CgminerMonitor
-  VERSION = "1.4.0"
+  VERSION = "1.5.0"
 
   def self.version
     VERSION

--- a/spec/cgminer_monitor/alert_evaluator_spec.rb
+++ b/spec/cgminer_monitor/alert_evaluator_spec.rb
@@ -375,7 +375,8 @@ RSpec.describe CgminerMonitor::AlertEvaluator do
 
     context 'with a restart_schedule_client reporting the miner is in its window' do
       let(:restart_schedule_client) do
-        instance_double(CgminerMonitor::RestartScheduleClient, in_restart_window?: true)
+        instance_double(CgminerMonitor::RestartScheduleClient,
+                        in_restart_window?: true, in_drain?: false)
       end
       let(:evaluator) do
         described_class.new(config,
@@ -435,6 +436,8 @@ RSpec.describe CgminerMonitor::AlertEvaluator do
                                                .select { |l| l['event'] == 'alert.suppressed_during_restart_window' }
         rules = suppression_lines.map { |l| l['rule'] }
         expect(rules).to contain_exactly('offline', 'cold_dead')
+        # v1.5.0+: every suppression event carries a `cause:` discriminator.
+        expect(suppression_lines.map { |l| l['cause'] }).to all(eq('restart_window'))
       end
 
       it 'omits the built-in `offline` suppression row when only composites consume offline_seconds' do
@@ -460,9 +463,84 @@ RSpec.describe CgminerMonitor::AlertEvaluator do
       end
     end
 
+    context 'with a restart_schedule_client reporting the miner is in DRAIN (v1.5.0+)' do
+      let(:restart_schedule_client) do
+        instance_double(CgminerMonitor::RestartScheduleClient,
+                        in_restart_window?: false, in_drain?: true)
+      end
+      let(:evaluator) do
+        described_class.new(config,
+                            webhook_client: webhook_client,
+                            restart_schedule_client: restart_schedule_client)
+      end
+
+      before { seed_poll(at_time: now - 900, ok: true) }
+
+      it 'suppresses the offline rule with cause: :drain' do
+        log_io = StringIO.new
+        CgminerMonitor::Logger.output = log_io
+        CgminerMonitor::Logger.level = 'info'
+
+        evaluator.evaluate(now)
+
+        suppression_lines = log_io.string.lines.map { |l| JSON.parse(l) }
+                                               .select { |l| l['event'] == 'alert.suppressed_during_restart_window' }
+        expect(suppression_lines.map { |l| l['cause'] }).to all(eq('drain'))
+        expect(webhook_client).not_to have_received(:fire).with(hash_including(rule: 'offline'))
+      end
+
+      it 'emits one suppression line per rule consuming offline_seconds (built-in + composite)' do
+        log_io = StringIO.new
+        CgminerMonitor::Logger.output = log_io
+        CgminerMonitor::Logger.level = 'info'
+
+        composite_config = make_config(
+          'CGMINER_MONITOR_ALERTS_OFFLINE_AFTER_SECONDS' => '600',
+          'CGMINER_MONITOR_ALERTS_COMPOSITE_COLD_DEAD' => 'ghs_5s<100 & offline_seconds>60'
+        )
+        evaluator = described_class.new(composite_config,
+                                        webhook_client: webhook_client,
+                                        restart_schedule_client: restart_schedule_client)
+        evaluator.evaluate(now)
+
+        suppression_lines = log_io.string.lines.map { |l| JSON.parse(l) }
+                                               .select { |l| l['event'] == 'alert.suppressed_during_restart_window' }
+        rules = suppression_lines.map { |l| l['rule'] }
+        expect(rules).to contain_exactly('offline', 'cold_dead')
+        expect(suppression_lines.map { |l| l['cause'] }).to all(eq('drain'))
+      end
+    end
+
+    context 'with both in_restart_window? AND in_drain? returning true' do
+      let(:restart_schedule_client) do
+        instance_double(CgminerMonitor::RestartScheduleClient,
+                        in_restart_window?: true, in_drain?: true)
+      end
+      let(:evaluator) do
+        described_class.new(config,
+                            webhook_client: webhook_client,
+                            restart_schedule_client: restart_schedule_client)
+      end
+
+      before { seed_poll(at_time: now - 900, ok: true) }
+
+      it 'logs cause: :restart_window (first-true predicate wins)' do
+        log_io = StringIO.new
+        CgminerMonitor::Logger.output = log_io
+        CgminerMonitor::Logger.level = 'info'
+
+        evaluator.evaluate(now)
+
+        suppression_lines = log_io.string.lines.map { |l| JSON.parse(l) }
+                                               .select { |l| l['event'] == 'alert.suppressed_during_restart_window' }
+        expect(suppression_lines.map { |l| l['cause'] }).to all(eq('restart_window'))
+      end
+    end
+
     context 'with a restart_schedule_client reporting the miner is NOT in its window' do
       let(:restart_schedule_client) do
-        instance_double(CgminerMonitor::RestartScheduleClient, in_restart_window?: false)
+        instance_double(CgminerMonitor::RestartScheduleClient,
+                        in_restart_window?: false, in_drain?: false)
       end
       let(:evaluator) do
         described_class.new(config,

--- a/spec/cgminer_monitor/restart_schedule_client_spec.rb
+++ b/spec/cgminer_monitor/restart_schedule_client_spec.rb
@@ -82,6 +82,86 @@ RSpec.describe CgminerMonitor::RestartScheduleClient do
     end
   end
 
+  describe '#in_drain? (v1.5.0+)' do
+    let(:drained_payload) do
+      enabled_payload.merge(
+        'schedules' => [
+          enabled_payload['schedules'].first.merge(
+            'drained' => true,
+            'drained_at' => '2026-04-26T12:00:00.000Z',
+            'drained_by' => 'operator'
+          )
+        ]
+      )
+    end
+
+    let(:not_drained_payload) do
+      enabled_payload.merge(
+        'schedules' => [
+          enabled_payload['schedules'].first.merge('drained' => false, 'drained_at' => nil)
+        ]
+      )
+    end
+
+    let(:now) { Time.utc(2026, 4, 26, 12, 5, 0) }
+
+    it 'returns true for a drained miner' do
+      stub_request(:get, url).to_return(status: 200, body: JSON.generate(drained_payload))
+      expect(client.in_drain?('127.0.0.1:4028', now)).to be(true)
+    end
+
+    it 'returns false for a not-drained miner' do
+      stub_request(:get, url).to_return(status: 200, body: JSON.generate(not_drained_payload))
+      expect(client.in_drain?('127.0.0.1:4028', now)).to be(false)
+    end
+
+    it 'returns false when the drained field is absent (back-compat with pre-v1.8.0 manager)' do
+      stub_request(:get, url).to_return(status: 200, body: JSON.generate(enabled_payload))
+      expect(client.in_drain?('127.0.0.1:4028', now)).to be(false)
+    end
+
+    it 'returns false when drained is exactly true but drained_at is malformed' do
+      payload = enabled_payload.merge(
+        'schedules' => [enabled_payload['schedules'].first.merge('drained' => true,
+                                                                 'drained_at' => 'not-a-timestamp')]
+      )
+      stub_request(:get, url).to_return(status: 200, body: JSON.generate(payload))
+      expect(client.in_drain?('127.0.0.1:4028', now)).to be(false)
+    end
+
+    it 'returns false when drained is exactly true but drained_at is missing' do
+      payload = enabled_payload.merge(
+        'schedules' => [enabled_payload['schedules'].first.merge('drained' => true)]
+      )
+      stub_request(:get, url).to_return(status: 200, body: JSON.generate(payload))
+      expect(client.in_drain?('127.0.0.1:4028', now)).to be(false)
+    end
+
+    it 'returns false when drained is truthy-but-not-true (defensive — only exact `true` counts)' do
+      payload = enabled_payload.merge(
+        'schedules' => [enabled_payload['schedules'].first.merge('drained' => 'true',
+                                                                 'drained_at' => '2026-04-26T12:00:00Z')]
+      )
+      stub_request(:get, url).to_return(status: 200, body: JSON.generate(payload))
+      expect(client.in_drain?('127.0.0.1:4028', now)).to be(false)
+    end
+
+    it 'returns false for unknown miners' do
+      stub_request(:get, url).to_return(status: 200, body: JSON.generate(drained_payload))
+      expect(client.in_drain?('10.0.0.99:4028', now)).to be(false)
+    end
+
+    it 'fails open on manager fetch failure (returns false, not crash)' do
+      stub_request(:get, url).to_raise(Errno::ECONNREFUSED)
+      CgminerMonitor::Logger.output = StringIO.new
+      CgminerMonitor::Logger.level = 'error'
+      expect(client.in_drain?('127.0.0.1:4028', now)).to be(false)
+    ensure
+      CgminerMonitor::Logger.output = $stdout
+      CgminerMonitor::Logger.level = 'info'
+    end
+  end
+
   describe 'caching' do
     it 'does not re-hit the network within cache_seconds' do
       stub_request(:get, url).to_return(status: 200, body: JSON.generate(enabled_payload))


### PR DESCRIPTION
## Summary

Suppress `offline` alerts when a miner is intentionally drained, paired with the per-miner Drain / Resume flow shipping in `cgminer_manager` v1.8.0.

Two additive changes:

1. **`RestartScheduleClient#in_drain?(miner, now)`** — sibling to the existing `in_restart_window?` predicate. Reads `drained: true` + `drained_at` (ISO8601 UTC) from the per-miner record served by `cgminer_manager`'s `/api/v1/restart_schedules.json`. Older managers omit the drain fields and this predicate returns false for every miner — no version negotiation needed.

2. **`AlertEvaluator#populate_offline_readings`** consults the new predicate alongside the existing restart-window check. When either is true, the miner's `offline_seconds` atom nils for this tick (suppressing the built-in `offline` rule AND any composite that uses `offline_seconds`) and one `alert.suppressed_during_restart_window` event emits per affected rule with a new `cause:` Symbol field (`:restart_window` or `:drain`).

First-true predicate wins so a drained rig that's also inside its nightly restart window logs `cause: :restart_window` (the operationally-louder signal). Single grep target, single alerting integration; the new field is the discriminator instead of a new event name.

Schema entries reserved in `docs/log_schema.md`:

- `cause:` standard-key row (enum Symbol covering `:drain` / `:resume` / `:auto_resume` / `:restart_window`).
- `drained_at:` standard-key row (ISO8601 UTC).
- Five new `drain.*` event-catalog rows for the `cgminer_manager` v1.8.0 audit emissions: `drain.applied`, `drain.resumed`, `drain.failed`, `drain.indeterminate`, `drain.auto_resume_giving_up`.
- `alert.suppressed_during_restart_window` row extended with the new optional `cause:` field.

Bumps to v1.5.0.

## Test plan

- [x] `bundle exec rake` — all examples pass, RuboCop clean
- [x] `RestartScheduleClient#in_drain?` happy path + edge cases (drained absent, malformed `drained_at`, truthy-not-`true` defensive guard, unknown miner, manager fetch failure fail-open)
- [x] `AlertEvaluator` suppression with `cause: :drain` + `cause: :restart_window`; both-true precedence (restart_window wins); composite-rules-using-`offline_seconds` get one suppression line per affected rule
- [ ] CI green on full Mongo matrix

Required by `cgminer_manager` v1.8.0 — older monitors will treat drained rigs as offline and page the operator.
